### PR TITLE
Add support for the ambisonics 3 mix bus for premiere pro

### DIFF
--- a/audioelementplugin/src/AudioElementPluginProcessor.cpp
+++ b/audioelementplugin/src/AudioElementPluginProcessor.cpp
@@ -30,8 +30,7 @@
 int AudioElementPluginProcessor::instanceId_ = 0;
 
 AudioElementPluginProcessor::AudioElementPluginProcessor()
-    : ProcessorBase(juce::AudioChannelSet::mono(),
-                    juce::AudioChannelSet::ambisonic(5)),
+    : ProcessorBase(juce::AudioChannelSet::mono(), getHostWideLayout()),
       persistentState_(kAudioElementSpatialPluginStateKey),
       audioElementSpatialLayoutRepository_(
           persistentState_.getOrCreateChildWithName(
@@ -57,7 +56,8 @@ AudioElementPluginProcessor::AudioElementPluginProcessor()
   audioProcessors_.push_back(std::make_unique<SoundFieldProcessor>(
       &audioElementSpatialLayoutRepository_, &syncClient_, &ambisonicsData_));
   audioProcessors_.push_back(std::make_unique<RoutingProcessor>(
-      &audioElementSpatialLayoutRepository_, &syncClient_));
+      &audioElementSpatialLayoutRepository_, &syncClient_,
+      getBusesLayout().getMainOutputChannelSet().size()));
 
   Logger::getInstance().init("EclipsaAudioElementPlugin");
 
@@ -99,8 +99,7 @@ bool AudioElementPluginProcessor::isBusesLayoutSupported(
     return false;
   }
 
-  if (layouts.getMainOutputChannelSet() !=
-      juce::AudioChannelSet::ambisonic(5)) {
+  if (layouts.getMainOutputChannelSet() != getHostWideLayout()) {
     return false;
   }
 

--- a/common/data_structures/src/ChannelGains.cpp
+++ b/common/data_structures/src/ChannelGains.cpp
@@ -124,10 +124,10 @@ void ChannelGains::setChannelGain(const int& channel, const float& gain) {
 }
 
 void ChannelGains::setGains(std::vector<float> gains) {
-  if (gains.size() != totalChannels_) {
-    return;
+  size_t n = std::min(gains.size(), gains_.size());
+  for (int i = 0; i < n; ++i) {
+    gains_[i] = gains[i];
   }
-  gains_ = gains;
 }
 
 std::vector<std::string> ChannelGains::splitStringBySpace(

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -18,11 +18,7 @@
 
 //==============================================================================
 GainProcessor::GainProcessor(MultiChannelRepository* gainRepository)
-    : ProcessorBase(
-          BusesProperties()
-              .withInput("Input", juce::AudioChannelSet::ambisonic(5), true)
-              .withOutput("Output", juce::AudioChannelSet::ambisonic(5), true)),
-      numChannels(28),
+    : numChannels(getHostWideLayout().size()),
       gainrepo_id_(juce::Uuid()),
       channelGains_(gainRepository),  // passing an empty value tree, will
                                       // update in InitializeGainParameters
@@ -60,7 +56,7 @@ void GainProcessor::processBlock(juce::AudioBuffer<float>& buffer,
     setGain(i, gains_[i]->get());
   }
 
-  for (int i = 0; i < numChannels; i++) {
+  for (int i = 0; i < buffer.getNumChannels(); i++) {
     juce::dsp::AudioBlock<float> block(&buffer.getArrayOfWritePointers()[i], 1,
                                        m_samplesPerBlock_);
     juce::dsp::ProcessContextReplacing<float> processContext(block);

--- a/common/processors/processor_base/ProcessorBase.h
+++ b/common/processors/processor_base/ProcessorBase.h
@@ -91,4 +91,12 @@ class ProcessorBase : public juce::AudioProcessor {
   void changeProgramName(int index, const juce::String& newName) override {
     juce::ignoreUnused(index, newName);
   }
+
+  static juce::AudioChannelSet getHostWideLayout() {
+    if (juce::PluginHostType().isPremiere()) {
+      return juce::AudioChannelSet::ambisonic(3);
+    } else {
+      return juce::AudioChannelSet::ambisonic(5);
+    }
+  }
 };

--- a/common/processors/routing/RoutingProcessor.cpp
+++ b/common/processors/routing/RoutingProcessor.cpp
@@ -20,11 +20,12 @@
 
 RoutingProcessor::RoutingProcessor(
     AudioElementSpatialLayoutRepository* audioElementSpatialLayoutRepository,
-    AudioElementPluginSyncClient* syncClient)
+    AudioElementPluginSyncClient* syncClient, int totalChannelCount)
     : audioElementSpatialLayoutData_(audioElementSpatialLayoutRepository),
       syncClient_(syncClient),
       firstChannel_(0),
-      totalChannels_(0) {
+      totalChannels_(0),
+      totalChannelCount_(totalChannelCount) {
   // Register ourselves to listen for updates to the AudioElementSpatialLayout
   // and/or audio element data
   audioElementSpatialLayoutData_->registerListener(this);
@@ -40,7 +41,7 @@ RoutingProcessor::~RoutingProcessor() {
 
 void RoutingProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
   juce::ignoreUnused(sampleRate);
-  copyBuffer_.setSize(getTotalNumOutputChannels(), samplesPerBlock);
+  copyBuffer_.setSize(totalChannelCount_, samplesPerBlock);
 }
 
 void RoutingProcessor::initializeRouting() {

--- a/common/processors/routing/RoutingProcessor.h
+++ b/common/processors/routing/RoutingProcessor.h
@@ -30,7 +30,7 @@ class RoutingProcessor final : public ProcessorBase,
   //==============================================================================
   RoutingProcessor(
       AudioElementSpatialLayoutRepository* AudioElementSpatialLayoutRepository,
-      AudioElementPluginSyncClient* syncClient);
+      AudioElementPluginSyncClient* syncClient, int totalChannelCount);
   ~RoutingProcessor() override;
 
   //==============================================================================
@@ -79,6 +79,7 @@ class RoutingProcessor final : public ProcessorBase,
   // Playback information required for shifting the audio channels
   std::atomic_int firstChannel_;
   std::atomic_int totalChannels_;
+  const int totalChannelCount_;
   juce::AudioBuffer<float> copyBuffer_;
 
   //==============================================================================

--- a/common/processors/tests/AudioElementPluginRouting_test.cpp
+++ b/common/processors/tests/AudioElementPluginRouting_test.cpp
@@ -60,7 +60,7 @@ TEST(test_routing_processor, test_no_shift) {
 
   // Create an instance of the routing processor
   RoutingProcessor routing_processor(&audioElementSpatialLayout_repository,
-                                     &sync_client);
+                                     &sync_client, 36);
 
   // Create an instance of the audio buffer with 10 channels, filling the first
   // two with 1's and the rest with 0's
@@ -118,7 +118,7 @@ TEST(test_routing_processor, test_partial_shift) {
 
   // Create an instance of the routing processor
   RoutingProcessor routing_processor(&audioElementSpatialLayout_repository,
-                                     &sync_client);
+                                     &sync_client, 36);
 
   // Create an instance of the audio buffer with 10 channels, filling the first
   // two with 1's and 2's and the rest with 0's
@@ -178,7 +178,7 @@ TEST(test_routing_processor, test_full_shift) {
 
   // Create an instance of the routing processor
   RoutingProcessor routing_processor(&audioElementSpatialLayout_repository,
-                                     &sync_client);
+                                     &sync_client, 36);
 
   // Create an instance of the audio buffer with 10 channels, filling the first
   // two with 1's and the rest with 0's

--- a/common/processors/tests/GainProcessor_test.cpp
+++ b/common/processors/tests/GainProcessor_test.cpp
@@ -34,8 +34,8 @@ void ensureGainsStoredandUpdated() {
       "After set update: " + gainRepository.get().toValueTree().toXmlString());
 
   // Validate the GainProcessor is allocating room for 28 channels
-  ASSERT_EQ(gainProcessor.getGainRepoInputChannels(), 28);
-  ASSERT_EQ(gainProcessor.getGains().size(), 28);
+  ASSERT_GE(gainProcessor.getGainRepoInputChannels(), 28);
+  ASSERT_GE(gainProcessor.getGains().size(), 28);
 
   // validate that the gains have the correct values
   for (int i = 0; i < 28; i++) {

--- a/common/processors/tests/Panner3DProcessor_Test.cpp
+++ b/common/processors/tests/Panner3DProcessor_Test.cpp
@@ -71,7 +71,7 @@ TEST(test_3D_render_Processor, test_simple_pan) {
 
   // Create a routing processor
   RoutingProcessor routing_processor(&audioElementSpatialLayout_repository,
-                                     &sync_client);
+                                     &sync_client, 36);
 
   // Create a parameter tree
   AudioElementParameterTree parameter_tree(routing_processor);

--- a/rendererplugin/src/RendererEditor.cpp
+++ b/rendererplugin/src/RendererEditor.cpp
@@ -65,7 +65,8 @@ RendererEditor::RendererEditor(RendererProcessor& p)
       dawWarningBanner_(&p.getRoomSetupRepository()),
       currentScreen_(&monitorScreen_),
       monitorScreen_(p.getRepositories(), p.getSpeakerMonitorData(), *this,
-                     p.getChannelMonitorProcessor()) {
+                     p.getChannelMonitorProcessor(),
+                     p.getMainBusNumInputChannels()) {
   setResizable(true, true);
   setSize(1600, 752);
 

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -26,8 +26,7 @@
 
 //==============================================================================
 RendererProcessor::RendererProcessor()
-    : ProcessorBase(juce::AudioChannelSet::ambisonic(5),
-                    juce::AudioChannelSet::stereo()),
+    : ProcessorBase(getHostWideLayout(), juce::AudioChannelSet::stereo()),
       // Load persistent state. Initialize repositories from persistent state.
       persistentState_(kRendererStateKey),
       roomSetupRepository_(getTreeWithId(kRoomSetupKey)),
@@ -89,7 +88,7 @@ RendererProcessor::~RendererProcessor() {}
 bool RendererProcessor::isBusesLayoutSupported(
     const BusesLayout& layouts) const {
   // Ensure the input channel set is wide enough for us
-  if (layouts.getMainInputChannelSet() != juce::AudioChannelSet::ambisonic(5)) {
+  if (layouts.getMainInputChannelSet() != getHostWideLayout()) {
     return false;
   }
 

--- a/rendererplugin/src/screens/ElementRoutingScreen.cpp
+++ b/rendererplugin/src/screens/ElementRoutingScreen.cpp
@@ -14,7 +14,6 @@
 
 #include "ElementRoutingScreen.h"
 
-#include <ostream>
 #include <vector>
 
 #include "../RendererProcessor.h"
@@ -25,7 +24,6 @@
 #include "data_structures/src/AudioElement.h"
 #include "data_structures/src/AudioElementSpatialLayout.h"
 #include "data_structures/src/FileExport.h"
-#include "juce_core/system/juce_PlatformDefs.h"
 #include "logger/logger.h"
 #include "substream_rdr/substream_rdr_utils/Speakers.h"
 
@@ -34,7 +32,7 @@ ElementRoutingScreen::ElementRoutingScreen(
     MultibaseAudioElementSpatialLayoutRepository*
         AudioElementSpatialLayoutRepository,
     FileExportRepository* fileExportRepository,
-    MixPresentationRepository* mixPresentationRepository)
+    MixPresentationRepository* mixPresentationRepository, int totalChanneCount)
     : audioElementRepository_(audioElementRepository),
       audioElementSpatialLayoutRepository_(AudioElementSpatialLayoutRepository),
       fileExportRepository_(fileExportRepository),
@@ -58,8 +56,17 @@ ElementRoutingScreen::ElementRoutingScreen(
   // Set profile selection
   FileExport profileConfig = fileExportRepository_->get();
   profileSelectionBox_.addOption("Simple");
-  profileSelectionBox_.addOption("Base");
-  profileSelectionBox_.addOption("Base Enhanced");
+
+  // Add the base option to the profile config only if 18 channels are
+  // available, as the base profile supports 18 channels
+  if (totalChanneCount >= 18) {
+    profileSelectionBox_.addOption("Base");
+  }
+  // Add the base option to the profile config only if 28 channels are
+  // available, as the base enhanced profile supports 28 channels
+  if (totalChanneCount >= 28) {
+    profileSelectionBox_.addOption("Base Enhanced");
+  }
   profileSelectionBox_.onChange([this]() {
     FileExport profileConfig = fileExportRepository_->get();
     int idx = profileSelectionBox_.getSelectedIndex();

--- a/rendererplugin/src/screens/ElementRoutingScreen.h
+++ b/rendererplugin/src/screens/ElementRoutingScreen.h
@@ -20,7 +20,6 @@
 #include <memory>
 #include <vector>
 
-#include "../RendererPluginSyncServer.h"
 #include "components/src/ColouredLight.h"
 #include "components/src/EclipsaColours.h"
 #include "components/src/HeaderBar.h"
@@ -32,7 +31,6 @@
 #include "data_repository/implementation/AudioElementRepository.h"
 #include "data_repository/implementation/AudioElementSpatialLayoutRepository.h"
 #include "data_repository/implementation/MixPresentationRepository.h"
-#include "data_repository/repository_base/RepositoryMultiBase.h"
 #include "data_structures/src/AudioElement.h"
 #include "data_structures/src/FileExport.h"
 #include "substream_rdr/substream_rdr_utils/Speakers.h"
@@ -63,7 +61,8 @@ class ElementRoutingScreen : public juce::Component,
                        MultibaseAudioElementSpatialLayoutRepository*
                            audioElementSpatialLayoutRepository,
                        FileExportRepository* fileExportRepository,
-                       MixPresentationRepository* mixPresentationRepository);
+                       MixPresentationRepository* mixPresentationRepository,
+                       int totalChanneCount);
 
   ~ElementRoutingScreen();
 

--- a/rendererplugin/src/screens/MonitorScreen.h
+++ b/rendererplugin/src/screens/MonitorScreen.h
@@ -17,16 +17,9 @@
 #pragma once
 #include <components/components.h>
 
-#include "../RendererProcessor.h"
 #include "MixMonitoringScreen.h"
 #include "PresentationMonitorScreen.h"
 #include "RoomMonitoringScreen.h"
-#include "data_repository/implementation/AudioElementRepository.h"
-#include "data_repository/implementation/AudioElementSpatialLayoutRepository.h"
-#include "data_repository/implementation/FileExportRepository.h"
-#include "data_repository/implementation/MixPresentationRepository.h"
-#include "data_repository/implementation/RoomSetupRepository.h"
-#include "data_structures/src/AudioElement.h"
 
 class MonitorScreen : public juce::Component {
   PresentationMonitorScreen presentationMonitorScreen_;
@@ -36,11 +29,13 @@ class MonitorScreen : public juce::Component {
  public:
   MonitorScreen(RepositoryCollection repos, SpeakerMonitorData& data,
                 MainEditor& editor,
-                ChannelMonitorProcessor* channelMonitorProcessor)
+                ChannelMonitorProcessor* channelMonitorProcessor,
+                int totalChannelCount)
       : presentationMonitorScreen_(
             editor, &repos.aeRepo_, &repos.audioElementSpatialLayoutRepo_,
             &repos.mpRepo_, &repos.mpSMRepo_, &repos.chGainRepo_,
-            &repos.activeMPRepo_, channelMonitorProcessor, &repos.fioRepo_),
+            &repos.activeMPRepo_, channelMonitorProcessor, &repos.fioRepo_,
+            totalChannelCount),
         roomMonitoringScreen_(repos, data, editor),
         mixMonitoringScreen_(repos, data) {}
 

--- a/rendererplugin/src/screens/PresentationMonitorScreen.cpp
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.cpp
@@ -48,10 +48,10 @@ PresentationMonitorScreen::PresentationMonitorScreen(
     MultiChannelRepository* multiChannelRepository,
     ActiveMixRepository* activeMixRepo,
     ChannelMonitorProcessor* channelMonitorProcessor,
-    FileExportRepository* fileExportRepository)
-    : elementRoutingScreen_(editor, ae_repository,
-                            audioElementSpatialLayout_repository,
-                            fileExportRepository, mixPresentationRepository),
+    FileExportRepository* fileExportRepository, int totalChannelCount)
+    : elementRoutingScreen_(
+          editor, ae_repository, audioElementSpatialLayout_repository,
+          fileExportRepository, mixPresentationRepository, totalChannelCount),
       editPresentationScreen_(editor, ae_repository, mixPresentationRepository,
                               activeMixRepo),
       presentationTabs_(std::make_unique<CustomTabbedComponent>()),

--- a/rendererplugin/src/screens/PresentationMonitorScreen.h
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.h
@@ -55,7 +55,7 @@ class PresentationMonitorScreen : public juce::Component,
       MultiChannelRepository* multiChannelRepository,
       ActiveMixRepository* activeMixRepo,
       ChannelMonitorProcessor* channelMonitorProcessor,
-      FileExportRepository* fileExportRepository);
+      FileExportRepository* fileExportRepository, int totalChannelCount);
 
   ~PresentationMonitorScreen();
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -100,7 +100,7 @@ COMPANY_NAME="${ECLIPSA_COMPANY_NAME:-Eclipsa Project}"
 COPYRIGHT_YEAR="${ECLIPSA_COPYRIGHT_YEAR:-2025}"
 BUNDLE_IDENTIFIER="${ECLIPSA_BUNDLE_IDENTIFIER:-com.eclipsaproject.plugins}"
 VERSION="${ECLIPSA_VERSION:-1.0.0}"
-DOCS_URL="${ECLIPSA_DOCS_URL:-https://github.com/eclipsaproject/docs}"
+DOCS_URL="${ECLIPSA_DOCS_URL:-https://docs.eclipsaapp.com}"
 
 # DMG appearance
 DMG_TITLE="${ECLIPSA_DMG_TITLE:-Eclipsa Plugins Installer}"
@@ -158,6 +158,15 @@ WRAP_TOOL_HELPER="./wraptool_helper.sh"
 
 # Define output filenames
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+if [ "$BRANCH_NAME" = "HEAD" ]; then
+    # If we're in a detached HEAD state, or have checked out a tag, fetch the tag
+    BRANCH_NAME=$(git describe --tags --exact-match 2>/dev/null)
+
+    # If no tag is found, fallback to commit info
+    if [ -z "$BRANCH_NAME" ]; then
+        BRANCH_NAME=$(git rev-parse --short HEAD)
+    fi
+fi
 
 INSTALLER_NAME="Eclipsa_${FORMAT_SUFFIX}_${BRANCH_NAME}.pkg"
 FINAL_DMG_NAME="Eclipsa_Plugins_${FORMAT_SUFFIX}_${BRANCH_NAME}.dmg"


### PR DESCRIPTION
### Description
Moving forward the plugin needs to work with Ambisonics 3 to support Premiere Pro. We should try and set up our processors so that they don't depend on the bus size being fixed and instead properly work with an arbitrary sized bus.

I've updated a couple processors that did not work properly with the dynamically sized bus, and updated the UI to reflect limited support when a smaller bus size is used. 

For Premiere Pro, we construct with a 3rd order ambisonics bus so that the plugin can be instantiated properly.

### Changes
- Modify plugin constructors to construct Ambisonic 3 when using Premiere Pro
- Drop support for Base and Base Enhanced profiles when there aren't enough channels
- Fix gain processor to work with arbitrary bus size
- Fix routing processor to work with arbitrary bus size

### Validation and Acceptance Criteria
- Updated unit tests
- Manual Testing in plugin host / REAPER / Premiere Pro
- For manual testing in plugin host / REAPER perform setup and export as typical, there should be no discernible changes

Manual Test Steps - Premier Pro
- Open Premiere Pro and start a new project
- Create a new sequence with 16 channels: File --> New --> Sequence... --> Tracks
  - Under Tracks select "Mix: Multichannel" "# of Channels: 16"
  - Remove all but 1 audio track
  - Ensure the remaining audio track is "Track Type: Adaptive"
- Open the "Audio Clip Mixer" if it's not open already "Window --> Audio Clip Mixer"
- In the audio clip mixer, select "Effect Controls" --> "Manage Audio Plug-Ins"
- Scan for plug-ins and insure the Eclipse plugin are present
- Return to the sequence editor and add the Renderer to the mix bus and the audio element plugin to the audio track
- Add audio to the track by dragging and dropping an mp3 file onto the track
- playback audio
