### PR TITLE
Prevent simultaneous processBlock and setNonRealtime calls

### DIFF
--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -162,6 +162,10 @@ void RendererProcessor::processBlock(juce::AudioBuffer<float>& buffer,
                                      juce::MidiBuffer& midiMessages) {
   juce::ignoreUnused(midiMessages);
 
+#if JUCE_DEBUG
+  juce::SpinLock::ScopedLockType realtimeLock(realtimeLock_);
+#endif
+
   juce::ScopedNoDenormals noDenormals;
   auto totalNumInputChannels = getTotalNumInputChannels();
   auto totalNumOutputChannels = getTotalNumOutputChannels();
@@ -276,17 +280,22 @@ juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter() {
 }
 
 void RendererProcessor::checkManualOfflineStartStop() {
-  // This is utilized by debug builds to perform the manual bounce operation
+// This is utilized by debug builds to perform the manual bounce operation
+#if JUCE_DEBUG
+  juce::SpinLock::ScopedLockType realtimeLock(realtimeLock_);
   FileExport configParams = fileExportRepository_.get();
   if (isRealtime_ != configParams.getManualExport()) {
     isRealtime_ = configParams.getManualExport();
     setNonRealtime(isRealtime_);
   }
+#endif
 }
+
 void RendererProcessor::valueTreeRedirected(
     juce::ValueTree& treeWhichHasBeenChanged) {
   checkManualOfflineStartStop();
 }
+
 void RendererProcessor::valueTreePropertyChanged(
     juce::ValueTree& treeWhosePropertyHasChanged,
     const juce::Identifier& property) {

--- a/rendererplugin/src/RendererProcessor.h
+++ b/rendererplugin/src/RendererProcessor.h
@@ -170,6 +170,9 @@ class RendererProcessor final : public ProcessorBase,
 
   juce::AudioChannelSet outputChannelSet_ = juce::AudioChannelSet::stereo();
 
+  // Used by the debug build to prevent processing while changing
+  // to non-realtime mode
+  juce::SpinLock realtimeLock_;
   // Monitors if rendering in realtime mode or offline mode during debug builds
   // only
   bool isRealtime_;


### PR DESCRIPTION
### Description
In debug builds we provide the capability to enable/disable realtime processing to allow export from the JUCE Audio Processor debugger as well as Avid ProTools developer version. Typically DAW's will call enable/disable realtime processing and then playback audio however when we allow this manual playback we can enable/disable realtime processing while audio playback is occurring, which occasionally leads to a race condition where audio is written to deleted or uninitialized WAV files.

In debug builds, add a lock to prevent the realtime processing switch from occuring during a processBlock call.

### Changes
- In debug builds, added a lock to processBlock and setRealtime

### Validation and Acceptance Criteria
Manual testing steps:
- Compile in debug mode and run in the JUCE Audio Processor debugger environment
- Configure and IAMF file export and muxing
- Start/Stop the manual file export several times, ensuring it does not crash