### PR TITLE
Bug_Fix: File Export Screen

### DIFF
--- a/rendererplugin/src/RendererProcessor.h
+++ b/rendererplugin/src/RendererProcessor.h
@@ -108,8 +108,6 @@ class RendererProcessor final : public ProcessorBase,
     return channelMonitorProcessor_;
   }
 
-  inline static const juce::Identifier kFileExportKey{"file_export"};
-
  private:
   void updateRepositories();
 
@@ -146,6 +144,7 @@ class RendererProcessor final : public ProcessorBase,
   RendererPluginSyncServer syncServer_;
 
   FileExportRepository fileExportRepository_;
+  inline static const juce::Identifier kFileExportKey{"file_export"};
 
   MixPresentationRepository mixPresentationRepository_;
   inline static const juce::Identifier kMixPresentationsKey{

--- a/rendererplugin/src/RendererProcessor.h
+++ b/rendererplugin/src/RendererProcessor.h
@@ -108,6 +108,8 @@ class RendererProcessor final : public ProcessorBase,
     return channelMonitorProcessor_;
   }
 
+  inline static const juce::Identifier kFileExportKey{"file_export"};
+
  private:
   void updateRepositories();
 
@@ -144,7 +146,6 @@ class RendererProcessor final : public ProcessorBase,
   RendererPluginSyncServer syncServer_;
 
   FileExportRepository fileExportRepository_;
-  inline static const juce::Identifier kFileExportKey{"file_export"};
 
   MixPresentationRepository mixPresentationRepository_;
   inline static const juce::Identifier kMixPresentationsKey{

--- a/rendererplugin/src/screens/FileExportScreen.cpp
+++ b/rendererplugin/src/screens/FileExportScreen.cpp
@@ -14,7 +14,10 @@
 
 #include "FileExportScreen.h"
 
+#include "../RendererProcessor.h"
+#include "components/src/EclipsaColours.h"
 #include "data_structures/src/FileExport.h"
+#include "data_structures/src/MixPresentation.h"
 
 FileExportScreen::FileExportScreen(MainEditor& editor,
                                    RepositoryCollection repos)
@@ -47,13 +50,14 @@ FileExportScreen::FileExportScreen(MainEditor& editor,
           "Select a file to output mux video to",
           juce::File::getSpecialLocation(juce::File::userDesktopDirectory),
           "*.mp4;*.mov"),
-      exportButton_("Start manual export"),
+      exportButton_("Start Export"),
       repository_(&repos.fioRepo_),
       aeRepository_(&repos.aeRepo_),
       mpRepository_(&repos.mpRepo_) {
   // Setup listeners to know when to redraw the screen
   aeRepository_->registerListener(this);
   mpRepository_->registerListener(this);
+  repository_->registerListener(this);
 
   // Fetch the current configuration for setting up the screen
   FileExport config = repository_->get();
@@ -255,13 +259,12 @@ FileExportScreen::FileExportScreen(MainEditor& editor,
   // Finally, set up the manual export button
   exportButton_.onClick = [this] {
     FileExport config = repository_->get();
+    if (juce::PluginHostType().isPremiere() && !validFileExportConfig(config)) {
+      return;
+    }
     config.setManualExport(!config.getManualExport());
     repository_->update(config);
     if (config.getManualExport()) {
-      exportButton_.setButtonText("Stop manual export");
-      exportButton_.setColour(juce::TextButton::ColourIds::textColourOffId,
-                              EclipsaColours::red);
-
       startTimer_.setEnabled(false);
       endTimer_.setEnabled(false);
       formatSelector_.setEnabled(false);
@@ -278,10 +281,6 @@ FileExportScreen::FileExportScreen(MainEditor& editor,
       browseVideoSourceButton_.setEnabled(false);
 
     } else {
-      exportButton_.setButtonText("Start manual export");
-      exportButton_.setColour(juce::TextButton::textColourOffId,
-                              EclipsaColours::green);
-
       startTimer_.setEnabled(true);
       endTimer_.setEnabled(true);
       formatSelector_.setEnabled(true);
@@ -303,12 +302,18 @@ FileExportScreen::FileExportScreen(MainEditor& editor,
 
   // Redraw the non-configurable components
   refreshComponents();
+
+  addAndMakeVisible(warningLabel_);
+  warningLabel_.setColour(juce::Label::ColourIds::textColourId,
+                          EclipsaColours::red);
+  refreshFileExportComponents();
 }
 
 FileExportScreen::~FileExportScreen() {
   setLookAndFeel(nullptr);
   aeRepository_->deregisterListener(this);
   mpRepository_->deregisterListener(this);
+  repository_->deregisterListener(this);
 }
 
 void FileExportScreen::paint(juce::Graphics& g) {
@@ -462,9 +467,13 @@ void FileExportScreen::paint(juce::Graphics& g) {
   // Draw in the manual export button
   if (juce::PluginHostType().isPremiere()) {
     bounds.removeFromTop(columnPadding);
-    row = bounds.removeFromTop(rowHeight);
+    row = bounds.removeFromTop(rowHeight * 0.75f);
+    const auto rowReference = row;
     addAndMakeVisible(exportButton_);
-    exportButton_.setBounds(row.removeFromLeft(200));
+    exportButton_.setBounds(row.removeFromLeft(125));
+    auto labelBounds = rowReference;
+    labelBounds.removeFromLeft(exportButton_.getWidth());
+    warningLabel_.setBounds(labelBounds);
   } else {
 #if JUCE_DEBUG
     bounds.removeFromTop(columnPadding);
@@ -517,11 +526,6 @@ void FileExportScreen::refreshComponents() {
   // Set the mix presentation count
   mixPresentations_.setText(juce::String(mpRepository_->getItemCount()));
 
-  // Set the sample rate information if possible
-  FileExport config = repository_->get();
-  if (config.getSampleRate() > 0) {
-    sampleRate_.setText(juce::String(config.getSampleRate()) + " Hz");
-  }
   repaint();
 }
 
@@ -593,22 +597,87 @@ void FileExportScreen::configureCustomCodecParameter(AudioCodec format) {
 
 void FileExportScreen::valueTreeRedirected(
     juce::ValueTree& treeWhichHasBeenChanged) {
-  refreshComponents();
+  if (treeWhichHasBeenChanged.getType() == RendererProcessor::kFileExportKey) {
+    refreshFileExportComponents();
+  } else {
+    refreshComponents();
+  }
 }
 
 void FileExportScreen::valueTreePropertyChanged(
     juce::ValueTree& treeWhosePropertyHasChanged,
     const juce::Identifier& property) {
-  refreshComponents();
+  if (treeWhosePropertyHasChanged.getType() ==
+      RendererProcessor::kFileExportKey) {
+    refreshFileExportComponents();
+  } else {
+    refreshComponents();
+  }
 }
 
 void FileExportScreen::valueTreeChildAdded(
     juce::ValueTree& parentTree, juce::ValueTree& childWhichHasBeenAdded) {
-  refreshComponents();
+  if (childWhichHasBeenAdded.getType() == RendererProcessor::kFileExportKey) {
+    refreshFileExportComponents();
+  } else {
+    refreshComponents();
+  }
 }
 
 void FileExportScreen::valueTreeChildRemoved(
     juce::ValueTree& parentTree, juce::ValueTree& childWhichHasBeenRemoved,
     int indexFromWhichChildWasRemoved) {
-  refreshComponents();
+  if (childWhichHasBeenRemoved.getType() == RendererProcessor::kFileExportKey) {
+    refreshFileExportComponents();
+  } else {
+    refreshComponents();
+  }
+}
+
+void FileExportScreen::refreshFileExportComponents() {
+  // Set the sample rate information if possible
+  FileExport config = repository_->get();
+  if (config.getSampleRate() > 0) {
+    sampleRate_.setText(juce::String(config.getSampleRate()) + " Hz");
+  }
+
+  if (config.getManualExport()) {
+    exportButton_.setButtonText("Stop Export");
+    exportButton_.setColour(juce::TextButton::ColourIds::textColourOffId,
+                            EclipsaColours::red);
+  } else {
+    exportButton_.setButtonText("Start Export");
+    exportButton_.setColour(juce::TextButton::textColourOffId,
+                            EclipsaColours::green);
+  }
+
+  repaint();
+}
+
+bool FileExportScreen::validFileExportConfig(const FileExport& config) {
+  // Check if the export file is valid
+  if (config.getExportFile().isEmpty()) {
+    warningLabel_.setVisible(true);
+    warningLabel_.setText("Must Specify a .IAMF File to Export",
+                          juce::NotificationType::dontSendNotification);
+    return false;
+  }
+
+  juce::OwnedArray<MixPresentation> mixPresentations;
+  mpRepository_->getAll(mixPresentations);
+
+  for (const auto mixPres : mixPresentations) {
+    if (mixPres->getAudioElements().size() == 0) {
+      warningLabel_.setVisible(true);
+      juce::Uuid mixId = mixPres->getId();
+      juce::String mixName = mpRepository_->get(mixId).value().getName();
+      warningLabel_.setText("No audio elements in mix presentation: " + mixName,
+                            juce::NotificationType::dontSendNotification);
+      return false;
+    }
+  }
+
+  warningLabel_.setVisible(false);
+
+  return true;
 }

--- a/rendererplugin/src/screens/FileExportScreen.cpp
+++ b/rendererplugin/src/screens/FileExportScreen.cpp
@@ -597,7 +597,7 @@ void FileExportScreen::configureCustomCodecParameter(AudioCodec format) {
 
 void FileExportScreen::valueTreeRedirected(
     juce::ValueTree& treeWhichHasBeenChanged) {
-  if (treeWhichHasBeenChanged.getType() == RendererProcessor::kFileExportKey) {
+  if (treeWhichHasBeenChanged.getType() == repository_->getTree().getType()) {
     refreshFileExportComponents();
   } else {
     refreshComponents();
@@ -608,7 +608,7 @@ void FileExportScreen::valueTreePropertyChanged(
     juce::ValueTree& treeWhosePropertyHasChanged,
     const juce::Identifier& property) {
   if (treeWhosePropertyHasChanged.getType() ==
-      RendererProcessor::kFileExportKey) {
+      repository_->getTree().getType()) {
     refreshFileExportComponents();
   } else {
     refreshComponents();
@@ -617,7 +617,7 @@ void FileExportScreen::valueTreePropertyChanged(
 
 void FileExportScreen::valueTreeChildAdded(
     juce::ValueTree& parentTree, juce::ValueTree& childWhichHasBeenAdded) {
-  if (childWhichHasBeenAdded.getType() == RendererProcessor::kFileExportKey) {
+  if (childWhichHasBeenAdded.getType() == repository_->getTree().getType()) {
     refreshFileExportComponents();
   } else {
     refreshComponents();
@@ -627,7 +627,7 @@ void FileExportScreen::valueTreeChildAdded(
 void FileExportScreen::valueTreeChildRemoved(
     juce::ValueTree& parentTree, juce::ValueTree& childWhichHasBeenRemoved,
     int indexFromWhichChildWasRemoved) {
-  if (childWhichHasBeenRemoved.getType() == RendererProcessor::kFileExportKey) {
+  if (childWhichHasBeenRemoved.getType() == repository_->getTree().getType()) {
     refreshFileExportComponents();
   } else {
     refreshComponents();

--- a/rendererplugin/src/screens/FileExportScreen.h
+++ b/rendererplugin/src/screens/FileExportScreen.h
@@ -25,6 +25,7 @@
 #include "data_repository/implementation/AudioElementRepository.h"
 #include "data_repository/implementation/FileExportRepository.h"
 #include "data_repository/implementation/MixPresentationRepository.h"
+#include "data_structures/src/FileExport.h"
 
 class FileExportScreen : public juce::Component,
                          public juce::ValueTree::Listener {
@@ -34,6 +35,8 @@ class FileExportScreen : public juce::Component,
   ~FileExportScreen();
 
   void refreshComponents();
+
+  void refreshFileExportComponents();
 
   void paint(juce::Graphics& g);
 
@@ -50,6 +53,8 @@ class FileExportScreen : public juce::Component,
   void configureCustomCodecParameter(AudioCodec format);
   juce::String timeToString(int timeInMs);
   int stringToTime(juce::String val);
+
+  bool validFileExportConfig(const FileExport& config);
 
   FileExportRepository* repository_;
   AudioElementRepository* aeRepository_;
@@ -98,4 +103,5 @@ class FileExportScreen : public juce::Component,
 
   // Manual export button -- To be removed later
   juce::TextButton exportButton_;
+  juce::Label warningLabel_;
 };


### PR DESCRIPTION
### Description
Addressed a bug in the file export screen where the Export button would revert to "Start Export" if the Renderer Plugin's Editor was closed and re-opened.

### Changes
Ensure the getManualExport variable is always checked within the constructor of the FileExport Screen.
Added a warning label for attempting exports within a file destination and where any mix presentation has 0 audio elements.
Added listener call backs that update the information on the File Export Screen for any changes to the FileExport Repo.
![image](https://github.com/user-attachments/assets/8b52008a-9337-4ab9-afb4-70ea0ac269ac)
![image](https://github.com/user-attachments/assets/39c057bc-cf67-4f0f-9440-1a34ab639955)


### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ] Built the plugin locally and performed release testing
