### PR TITLE
Bug Fix: Prevent Audio Element SoloMute State from Resetting

### DIFF
--- a/common/components/src/loudness_meter/LoudnessMeter.cpp
+++ b/common/components/src/loudness_meter/LoudnessMeter.cpp
@@ -73,6 +73,7 @@ LoudnessMeter::LoudnessMeter(const juce::String chLabel, const int chIdx,
       msPlaybackRepo_(msPlaybackRepo),
       lookAndFeel_(msPlaybackRepo_),
       chLabel_(chLabel, chLabel) {
+  msPlaybackRepo_.registerListener(this);
   setLookAndFeel(&lookAndFeel_);
 
   addAndMakeVisible(loudnessBar_);
@@ -103,7 +104,10 @@ LoudnessMeter::LoudnessMeter(const juce::String chLabel, const int chIdx,
   addAndMakeVisible(muteButton_);
 }
 
-LoudnessMeter::~LoudnessMeter() { setLookAndFeel(nullptr); }
+LoudnessMeter::~LoudnessMeter() {
+  msPlaybackRepo_.deregisterListener(this);
+  setLookAndFeel(nullptr);
+}
 
 // Paint child components of the loudness meter.
 void LoudnessMeter::paint(juce::Graphics& g) {
@@ -177,4 +181,11 @@ juce::Rectangle<int> LoudnessMeter::getSMButtonsBounds() const {
   const auto soloBounds = soloButton_.getBounds();
   const auto muteBounds = muteButton_.getBounds();
   return soloBounds.getUnion(muteBounds);
+}
+
+void LoudnessMeter::valueTreePropertyChanged(
+    juce::ValueTree& treeWhosePropertyHasChanged,
+    const juce::Identifier& property) {
+  soloButton_.repaint();
+  muteButton_.repaint();
 }

--- a/common/components/src/loudness_meter/LoudnessMeter.h
+++ b/common/components/src/loudness_meter/LoudnessMeter.h
@@ -34,7 +34,7 @@ class MeterLookAndFeel : public juce::LookAndFeel_V4 {
   MSPlaybackRepository& msPlaybackRepo_;
 };
 
-class LoudnessMeter : public juce::Component {
+class LoudnessMeter : public juce::Component, juce::ValueTree::Listener {
  public:
   struct MSButton : public juce::TextButton {
     enum ButtonType { kSolo, kMute };
@@ -46,6 +46,9 @@ class LoudnessMeter : public juce::Component {
                 MSPlaybackRepository& msPlaybackRepo);
 
   ~LoudnessMeter();
+
+  void valueTreePropertyChanged(juce::ValueTree& treeWhosePropertyHasChanged,
+                                const juce::Identifier& property) override;
 
   void paint(juce::Graphics& g) override;
 

--- a/common/components/src/track_monitor_visuals/LoudnessMetersSet.cpp
+++ b/common/components/src/track_monitor_visuals/LoudnessMetersSet.cpp
@@ -29,7 +29,9 @@ LoudnessMetersSet::LoudnessMetersSet(
       playbackMSRepo_(audioElementPluginRepo.msRespository_),
       pbLayout_(pbLayout) {
   if (!pbLayout_.isAmbisonics()) {
-    updateMeters();
+    pbLayout_ = audioElementSpatialLayoutRepository_->get().getChannelLayout();
+    std::vector<juce::String> chLabels = pbLayout_.getSpeakerLabels();
+    createLoudnessMeters(chLabels);
   }
 }
 


### PR DESCRIPTION
### Description
Addressed a bug where the audio element plugin's solo mute state was reset when closed and re-opened.
Also ensured the Solo Mute buttons are updated correctly when toggled on/off

### Changes
Removed the resetSoloMute() function from being called within the constructor of the LoudnessMeterSet class.
Made the LoudnessMeter class a listener of the solo mute repo, so that the solo/mute buttons are repainted whenever a property is changed.

### Validation and Acceptance Criteria
- [ ] Manually tested the UI
- [ ] Steps necessary for others to validate your PR if different.
