### PR TITLE
fix persistence issue with active mix presentations

### DIFF
--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -355,19 +355,20 @@ void RendererProcessor::initializeMixPresentations() {
     LOG_ANALYTICS(instanceId_,
                   "setStateInformation: Created a new mix presentation and set "
                   "it as active.");
+    return; // Early return since we just set a valid active mix
   }
 
+  // Get the current active mix from the repository
   ActiveMixPresentation activeMix = activeMixPresentationRepository_.get();
   juce::Uuid activeMixId = activeMix.getActiveMixId();
 
-  if (activeMix.getActiveMixId() == juce::Uuid::null() ||
+  // Set first mix as active if current active mix is invalid (null or not found)
+  if (activeMixId == juce::Uuid::null() || 
       !mixPresentationRepository_.get(activeMixId).has_value()) {
-    // If no active mix presentation, set the first one as active.
-    activeMix.updateActiveMixId(mixPresentations[0]->getId());
-    activeMixPresentationRepository_.update(activeMix);
+    activeMixPresentationRepository_.update(mixPresentations[0]->getId());
     LOG_ANALYTICS(
         instanceId_,
-        "setStateInformation: Ensured the first mix presentation is active.");
+        "initializeMixPresentations: Set first mix presentation as active.");
   }
 }
 

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -355,15 +355,16 @@ void RendererProcessor::initializeMixPresentations() {
     LOG_ANALYTICS(instanceId_,
                   "setStateInformation: Created a new mix presentation and set "
                   "it as active.");
-    return; // Early return since we just set a valid active mix
+    return;  // Early return since we just set a valid active mix
   }
 
   // Get the current active mix from the repository
   ActiveMixPresentation activeMix = activeMixPresentationRepository_.get();
   juce::Uuid activeMixId = activeMix.getActiveMixId();
 
-  // Set first mix as active if current active mix is invalid (null or not found)
-  if (activeMixId == juce::Uuid::null() || 
+  // Set first mix as active if current active mix is invalid (null or not
+  // found)
+  if (activeMixId == juce::Uuid::null() ||
       !mixPresentationRepository_.get(activeMixId).has_value()) {
     activeMixPresentationRepository_.update(mixPresentations[0]->getId());
     LOG_ANALYTICS(

--- a/rendererplugin/src/screens/PresentationMonitorScreen.cpp
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.cpp
@@ -34,7 +34,8 @@ void CustomTabbedComponent::currentTabChanged(
     return;
   }
 
-  // Only update the active mix presentation if we're not in tab restoration mode
+  // Only update the active mix presentation if we're not in tab restoration
+  // mode
   if (!isRestoringTabs_) {
     tab->updateActiveMixPresentation();
     LOG_ANALYTICS(RendererProcessor::instanceId_,
@@ -208,15 +209,13 @@ void PresentationMonitorScreen::updateMixPresentations() {
 void PresentationMonitorScreen::updatePresentationTabs() {
   // Set flag to prevent active mix updates during tab restoration
   presentationTabs_->setTabRestorationMode(true);
-  
+
   // Use RAII to ensure flag is always cleared, even if exceptions occur
   struct RestorationGuard {
     CustomTabbedComponent* tabs;
-    ~RestorationGuard() { 
-      tabs->setTabRestorationMode(false);
-    }
+    ~RestorationGuard() { tabs->setTabRestorationMode(false); }
   } guard{presentationTabs_.get()};
-  
+
   presentationTabs_->clearTabs();
 
   // Add tabs for each mix

--- a/rendererplugin/src/screens/PresentationMonitorScreen.cpp
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.cpp
@@ -34,9 +34,12 @@ void CustomTabbedComponent::currentTabChanged(
     return;
   }
 
-  tab->updateActiveMixPresentation();
-  LOG_ANALYTICS(RendererProcessor::instanceId_,
-                "Tab changed to: " + newCurrentTabName.toStdString());
+  // Only update the active mix presentation if we're not in tab restoration mode
+  if (!isRestoringTabs_) {
+    tab->updateActiveMixPresentation();
+    LOG_ANALYTICS(RendererProcessor::instanceId_,
+                  "Tab changed to: " + newCurrentTabName.toStdString());
+  }
 }
 
 PresentationMonitorScreen::PresentationMonitorScreen(
@@ -203,6 +206,17 @@ void PresentationMonitorScreen::updateMixPresentations() {
 }
 
 void PresentationMonitorScreen::updatePresentationTabs() {
+  // Set flag to prevent active mix updates during tab restoration
+  presentationTabs_->setTabRestorationMode(true);
+  
+  // Use RAII to ensure flag is always cleared, even if exceptions occur
+  struct RestorationGuard {
+    CustomTabbedComponent* tabs;
+    ~RestorationGuard() { 
+      tabs->setTabRestorationMode(false);
+    }
+  } guard{presentationTabs_.get()};
+  
   presentationTabs_->clearTabs();
 
   // Add tabs for each mix

--- a/rendererplugin/src/screens/PresentationMonitorScreen.h
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.h
@@ -32,6 +32,11 @@ class CustomTabbedComponent : public juce::TabbedComponent {
 
   void currentTabChanged(int newCurrentTabIndex,
                          const juce::String& newCurrentTabName) override;
+  
+  void setTabRestorationMode(bool isRestoring) { isRestoringTabs_ = isRestoring; }
+
+ private:
+  bool isRestoringTabs_ = false;
 };
 
 class PresentationMonitorScreen : public juce::Component,

--- a/rendererplugin/src/screens/PresentationMonitorScreen.h
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.h
@@ -32,8 +32,10 @@ class CustomTabbedComponent : public juce::TabbedComponent {
 
   void currentTabChanged(int newCurrentTabIndex,
                          const juce::String& newCurrentTabName) override;
-  
-  void setTabRestorationMode(bool isRestoring) { isRestoringTabs_ = isRestoring; }
+
+  void setTabRestorationMode(bool isRestoring) {
+    isRestoringTabs_ = isRestoring;
+  }
 
  private:
   bool isRestoringTabs_ = false;


### PR DESCRIPTION
### Description
The root cause was JUCE's TabbedComponent automatically selecting the first tab during UI restoration, triggering unwanted repository updates that overwrote the saved active mix state.

The solution implements a restoration flag pattern in CustomTabbedComponent to distinguish between user-initiated tab changes and programmatic restoration during UI rebuild. This ensures that only genuine user interactions update the repository state, while preserving the correct active mix presentation across UI sessions.
### Changes

### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ] Active Mix Presentation tab selection persists across UI sessions.
- [ ] No unwanted state changes during UI restoration.
