### PR TITLE
Refactor ChannelMonitorProcessor

### DIFF
--- a/common/components/src/AEStripComponent.h
+++ b/common/components/src/AEStripComponent.h
@@ -23,8 +23,8 @@
 #include "data_repository/implementation/MixPresentationRepository.h"
 #include "data_repository/implementation/MixPresentationSoloMuteRepository.h"
 #include "data_repository/implementation/MultiChannelGainRepository.h"
-#include "data_structures/src/MixPresentation.h"
-#include "processors/channel_monitor/ChannelMonitorProcessor.h"
+#include "data_structures/src/ChannelMonitorData.h"
+#include "data_structures/src/RepositoryCollection.h"
 
 // Use this to specify how the S/M buttons should look
 class AEStripLookandFeel : public juce::LookAndFeel_V4 {
@@ -36,13 +36,10 @@ class AEStripComponent : public juce::Component,
                          public juce::Timer,
                          public juce::ValueTree::Listener {
  public:
-  AEStripComponent(
-      const int countChannel, const juce::String label,
-      const int startingChannel, MultiChannelRepository* multichannelGainRepo,
-      ChannelMonitorProcessor* channelMonitorProcessor,
-      const juce::Uuid audioelementID, const juce::Uuid mixPresID,
-      MixPresentationRepository* mixPresentationRepository,
-      MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository);
+  AEStripComponent(const int countChannel, const juce::String label,
+                   const int startingChannel, RepositoryCollection& repos,
+                   ChannelMonitorData& channelMonitorData,
+                   const juce::Uuid audioelementID, const juce::Uuid mixPresID);
   ~AEStripComponent();
 
   int getChannelCount() const { return channelCount_; }
@@ -126,8 +123,9 @@ class AEStripComponent : public juce::Component,
   // this holds the indices of the channels (0-15, 0-7, etc..)
   std::set<int> channelsSet_;
 
+  std::vector<float> channelLoudnessesRead_;
+  ChannelMonitorData& channelMonitorData_;
   MultiChannelRepository* multichannelGainRepo_;
-  ChannelMonitorProcessor* channelMonitorProcessor_;
   MixPresentationRepository* mixPresentationRepository_;
   MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository_;
 

--- a/common/data_repository/tests/MixPresentationSoloMuteRepository_test.cpp
+++ b/common/data_repository/tests/MixPresentationSoloMuteRepository_test.cpp
@@ -26,11 +26,9 @@ TEST(test_mix_presentation_solo_mute_repository, update) {
   MixPresentationSoloMuteRepository repositoryInstance(test);
 
   juce::Uuid presentationUuid = juce::Uuid();
-  MixPresentationSoloMute presentation(presentationUuid, "testPresentation",
-                                       false);
+  MixPresentationSoloMute presentation(presentationUuid, false);
   repositoryInstance.add(presentation);
 
-  presentation.setName("updatedName");
   juce::Uuid element = juce::Uuid();
   presentation.addAudioElement(element, 1, "AE1");
 

--- a/common/data_structures/src/ChannelMonitorData.h
+++ b/common/data_structures/src/ChannelMonitorData.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "RealtimeDataType.h"
+
+struct ChannelMonitorData {
+  void reinitializeLoudnesses(int numChannels) {
+    channelLoudnesses.update(std::vector<float>(numChannels, -300.f));
+  }
+  std::atomic_bool resetStats;
+  RealtimeDataType<std::vector<float>> channelLoudnesses;
+};

--- a/common/data_structures/src/MixPresentationSoloMute.cpp
+++ b/common/data_structures/src/MixPresentationSoloMute.cpp
@@ -19,10 +19,8 @@
 MixPresentationSoloMute::MixPresentationSoloMute()
     : RepositoryItemBase(juce::Uuid::null()) {}
 
-MixPresentationSoloMute::MixPresentationSoloMute(juce::Uuid id,
-                                                 juce::String name,
-                                                 bool anySoloed)
-    : RepositoryItemBase(id), mixPresName_(name), anySoloed_(anySoloed) {}
+MixPresentationSoloMute::MixPresentationSoloMute(juce::Uuid id, bool anySoloed)
+    : RepositoryItemBase(id), anySoloed_(anySoloed) {}
 
 void MixPresentationSoloMute::addAudioElement(const juce::Uuid id,
                                               const int referenceId,
@@ -73,8 +71,7 @@ MixPresentationSoloMute MixPresentationSoloMute::fromTree(
     const juce::ValueTree tree) {
   jassert(tree.hasProperty(kId));
 
-  MixPresentationSoloMute mixPres(juce::Uuid(tree[kId]), tree[kName],
-                                  tree[kAnySoloed]);
+  MixPresentationSoloMute mixPres(juce::Uuid(tree[kId]), tree[kAnySoloed]);
 
   juce::ValueTree audioElementsTree = tree.getChildWithName(kAudioElements);
   for (auto audioElementTree : audioElementsTree) {
@@ -86,9 +83,7 @@ MixPresentationSoloMute MixPresentationSoloMute::fromTree(
 }
 
 juce::ValueTree MixPresentationSoloMute::toValueTree() const {
-  juce::ValueTree tree(
-      kTreeType,
-      {{kId, id_.toString()}, {kName, mixPresName_}, {kAnySoloed, false}});
+  juce::ValueTree tree(kTreeType, {{kId, id_.toString()}, {kAnySoloed, false}});
 
   juce::ValueTree audioElementsTree =
       tree.getOrCreateChildWithName(kAudioElements, nullptr);
@@ -106,7 +101,7 @@ juce::ValueTree MixPresentationSoloMute::toValueTree() const {
 
 bool MixPresentationSoloMute::operator==(
     const MixPresentationSoloMute& other) const {
-  if (other.id_ != id_ || other.mixPresName_ != mixPresName_) {
+  if (other.id_ != id_) {
     return false;
   }
   for (auto audioElement = audioElements_.begin();

--- a/common/data_structures/src/MixPresentationSoloMute.h
+++ b/common/data_structures/src/MixPresentationSoloMute.h
@@ -26,7 +26,7 @@
 
 struct AudioElementSoloMute : public RepositoryItemBase {
  public:
-  AudioElementSoloMute() : RepositoryItemBase({}){};
+  AudioElementSoloMute() : RepositoryItemBase({}) {};
   AudioElementSoloMute(juce::Uuid id, int referenceID, const juce::String& name,
                        const bool isSoloed = false, const bool isMuted = false)
       : RepositoryItemBase(id),

--- a/common/data_structures/src/MixPresentationSoloMute.h
+++ b/common/data_structures/src/MixPresentationSoloMute.h
@@ -26,7 +26,7 @@
 
 struct AudioElementSoloMute : public RepositoryItemBase {
  public:
-  AudioElementSoloMute() : RepositoryItemBase({}) {};
+  AudioElementSoloMute() : RepositoryItemBase({}){};
   AudioElementSoloMute(juce::Uuid id, int referenceID, const juce::String& name,
                        const bool isSoloed = false, const bool isMuted = false)
       : RepositoryItemBase(id),
@@ -85,8 +85,7 @@ struct AudioElementSoloMute : public RepositoryItemBase {
 class MixPresentationSoloMute final : public RepositoryItemBase {
  public:
   MixPresentationSoloMute();
-  MixPresentationSoloMute(juce::Uuid id, juce::String name,
-                          bool anySoloed = false);
+  MixPresentationSoloMute(juce::Uuid id, bool anySoloed = false);
 
   bool operator==(const MixPresentationSoloMute& other) const;
   bool operator!=(const MixPresentationSoloMute& other) const {
@@ -96,8 +95,6 @@ class MixPresentationSoloMute final : public RepositoryItemBase {
   static MixPresentationSoloMute fromTree(const juce::ValueTree tree);
   virtual juce::ValueTree toValueTree() const override;
 
-  void setName(juce::String name) { mixPresName_ = name; }
-
   void addAudioElement(const juce::Uuid id, const int referenceID,
                        const juce::String& name);
 
@@ -106,8 +103,6 @@ class MixPresentationSoloMute final : public RepositoryItemBase {
   void setAudioElementSolo(const juce::Uuid& id, const bool isSoloed);
 
   void setAudioElementMute(const juce::Uuid& id, const bool isMuted);
-
-  juce::String getName() const { return mixPresName_; }
 
   AudioElementSoloMute getAudioElement(const juce::Uuid& id) const;
   std::vector<AudioElementSoloMute> getAudioElements() const {
@@ -121,12 +116,10 @@ class MixPresentationSoloMute final : public RepositoryItemBase {
   bool isAudioElementMuted(const juce::Uuid& id) const;
 
   inline static const juce::Identifier kTreeType{"mix_presentation_solo_mute"};
-  inline static const juce::Identifier kName{"presentation_name"};
   inline static const juce::Identifier kAudioElements{"audio_elements"};
   inline static const juce::Identifier kAnySoloed{"any_soloed"};
 
  private:
   std::vector<AudioElementSoloMute> audioElements_;
-  juce::String mixPresName_;
   bool anySoloed_;
 };

--- a/common/data_structures/tests/MixPresentationSoloMute_test.cpp
+++ b/common/data_structures/tests/MixPresentationSoloMute_test.cpp
@@ -19,8 +19,7 @@
 
 TEST(test_mix_presentation_solo_mute, validity) {
   // Create a mix presentation
-  MixPresentationSoloMute presentation1(juce::Uuid::null(), "TestPresentation",
-                                        false);
+  MixPresentationSoloMute presentation1(juce::Uuid::null(), false);
 
   juce::Uuid element1 = juce::Uuid();
   juce::Uuid element2 = juce::Uuid();
@@ -38,9 +37,6 @@ TEST(test_mix_presentation_solo_mute, validity) {
 
   presentation1.setAudioElementMute(element1, element1Muted);
   presentation1.setAudioElementMute(element2, element2Muted);
-
-  // Update some of it's values
-  presentation1.setName("UpdatedName");
 
   // Create a second presentation from the tree of the first
   MixPresentationSoloMute presentation2 =

--- a/common/processors/channel_monitor/ChannelMonitorProcessor.cpp
+++ b/common/processors/channel_monitor/ChannelMonitorProcessor.cpp
@@ -94,9 +94,6 @@ void ChannelMonitorProcessor::valueTreeChildAdded(
   else if (parentTree.getType() == MixPresentation::kTreeType &&
            childWhichHasBeenAdded.getType() ==
                MixPresentation::kAudioElements) {
-    juce::Logger::outputDebugString(parentTree.toXmlString());
-    juce::Logger::outputDebugString(childWhichHasBeenAdded.toXmlString());
-
     juce::Uuid mixPresID = juce::Uuid(parentTree[MixPresentation::kId]);
 
     // add Audio Element to SoloMute Repository
@@ -131,9 +128,6 @@ void ChannelMonitorProcessor::valueTreeChildRemoved(
   } else if (parentTree.getType() == MixPresentation::kTreeType &&
              childWhichHasBeenRemoved.getType() ==
                  MixPresentation::kAudioElements) {
-    juce::Logger::outputDebugString(parentTree.toXmlString());
-    juce::Logger::outputDebugString(childWhichHasBeenRemoved.toXmlString());
-
     juce::Uuid mixPresID = juce::Uuid(parentTree[MixPresentation::kId]);
 
     // remove Audio Element from SoloMute Repository

--- a/common/processors/channel_monitor/ChannelMonitorProcessor.cpp
+++ b/common/processors/channel_monitor/ChannelMonitorProcessor.cpp
@@ -14,15 +14,13 @@
 
 #include "ChannelMonitorProcessor.h"
 
-#include "processors/gain/MSProcessor.h"
+#include "data_structures/src/ChannelMonitorData.h"
 
-ChannelMonitorProcessor::ChannelMonitorProcessor()
-    : ProcessorBase(
-          BusesProperties()
-              .withInput("Input", juce::AudioChannelSet::ambisonic(5), true)
-              .withOutput("Output", juce::AudioChannelSet::ambisonic(5), true)),
-      numChannels_(juce::AudioChannelSet::ambisonic(5).size()),
-      loudness_(std::vector<float>(numChannels_)) {}
+ChannelMonitorProcessor::ChannelMonitorProcessor(
+    ChannelMonitorData& channelMonitorData)
+    : numChannels_(juce::AudioChannelSet::ambisonic(5).size()),
+      channelMonitorData_(channelMonitorData),
+      loudness_(std::vector<float>(numChannels_, -300.f)) {}
 
 ChannelMonitorProcessor::~ChannelMonitorProcessor() {}
 
@@ -43,9 +41,12 @@ void ChannelMonitorProcessor::processBlock(juce::AudioBuffer<float>& buffer,
     loudness_[i] =
         20.0f * std::log10(buffer.getRMSLevel(i, 0, buffer.getNumSamples()));
   }
+
   for (int i = buffer.getNumChannels(); i < numChannels_; i++) {
     loudness_[i] = -120.0f;
   }
+
+  channelMonitorData_.channelLoudnesses.update(loudness_);
 }
 
 bool ChannelMonitorProcessor::hasEditor() const {

--- a/common/processors/channel_monitor/ChannelMonitorProcessor.h
+++ b/common/processors/channel_monitor/ChannelMonitorProcessor.h
@@ -24,18 +24,17 @@
 
 #pragma once
 
-#include <data_structures/src/SpeakerMonitorData.h>
+#include <data_structures/src/ChannelMonitorData.h>
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_dsp/juce_dsp.h>
 
-#include "../../data_repository/implementation/AudioElementRepository.h"
 #include "../../data_repository/implementation/MixPresentationRepository.h"
 #include "../processor_base/ProcessorBase.h"
 
 //==============================================================================
 class ChannelMonitorProcessor final : public ProcessorBase {
  public:
-  ChannelMonitorProcessor();
+  ChannelMonitorProcessor(ChannelMonitorData& channelMonitorData);
   ~ChannelMonitorProcessor() override;
 
   void prepareToPlay(double sampleRate, int samplesPerBlock) override;
@@ -49,6 +48,7 @@ class ChannelMonitorProcessor final : public ProcessorBase {
   std::vector<float> getPrerdrLoudness() const { return loudness_; }
 
  private:
+  ChannelMonitorData& channelMonitorData_;
   int numChannels_;
   // replace with thread safe data-struct
   std::vector<float> loudness_;

--- a/common/processors/channel_monitor/ChannelMonitorProcessor.h
+++ b/common/processors/channel_monitor/ChannelMonitorProcessor.h
@@ -30,11 +30,16 @@
 
 #include "../../data_repository/implementation/MixPresentationRepository.h"
 #include "../processor_base/ProcessorBase.h"
+#include "data_repository/implementation/MixPresentationSoloMuteRepository.h"
 
 //==============================================================================
-class ChannelMonitorProcessor final : public ProcessorBase {
+class ChannelMonitorProcessor final : public ProcessorBase,
+                                      juce::ValueTree::Listener {
  public:
-  ChannelMonitorProcessor(ChannelMonitorData& channelMonitorData);
+  ChannelMonitorProcessor(
+      ChannelMonitorData& channelMonitorData,
+      MixPresentationRepository* mixPresentationRepository,
+      MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository);
   ~ChannelMonitorProcessor() override;
 
   void prepareToPlay(double sampleRate, int samplesPerBlock) override;
@@ -45,10 +50,17 @@ class ChannelMonitorProcessor final : public ProcessorBase {
 
   const juce::String getName() const override;
 
-  std::vector<float> getPrerdrLoudness() const { return loudness_; }
-
  private:
+  void valueTreeChildAdded(juce::ValueTree& parentTree,
+                           juce::ValueTree& childWhichHasBeenAdded) override;
+
+  void valueTreeChildRemoved(juce::ValueTree& parentTree,
+                             juce::ValueTree& childWhichHasBeenRemoved,
+                             int indexFromWhichChildWasRemoved) override;
+
   ChannelMonitorData& channelMonitorData_;
+  MixPresentationRepository* mixPresentationRepository_;
+  MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository_;
   int numChannels_;
   // replace with thread safe data-struct
   std::vector<float> loudness_;

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -78,12 +78,6 @@ bool GainProcessor::hasEditor() const {
   return false;  // (change this to false if you choose to not supply an editor)
 }
 
-//==============================================================================
-void GainProcessor::setStateInformation(const void* data, int sizeInBytes) {
-  std::unique_ptr<juce::XmlElement> xmlState(
-      getXmlFromBinary(data, sizeInBytes));
-}
-
 std::vector<juce::dsp::Gain<float>>
 GainProcessor::InitializeChannelGainsDSPs() {
   std::vector<juce::dsp::Gain<float>> channelGainsDSPs(gains_.size());

--- a/common/processors/gain/GainProcessor.h
+++ b/common/processors/gain/GainProcessor.h
@@ -56,9 +56,6 @@ class GainProcessor final : public ProcessorBase,
   //==============================================================================
   const juce::String getName() const override;
 
-  //==============================================================================
-  void setStateInformation(const void* data, int sizeInBytes) override;
-
   virtual void valueTreePropertyChanged(
       juce::ValueTree& tree, const juce::Identifier& property) override;
   virtual void valueTreeChildAdded(juce::ValueTree& parent,

--- a/common/processors/tests/ChannelMonitorProcessor_test.cpp
+++ b/common/processors/tests/ChannelMonitorProcessor_test.cpp
@@ -16,35 +16,20 @@
 
 #include <gtest/gtest.h>
 
+#include "data_structures/src/ChannelMonitorData.h"
 #include "data_structures/src/LanguageCodeMetaData.h"
 #include "data_structures/src/MixPresentation.h"
 #include "substream_rdr/substream_rdr_utils/Speakers.h"
 
 TEST(test_channelmonitor_processor, test_getPrerdrLoudness) {
-  AudioElementRepository audioElementRepository_ =
-      juce::ValueTree("audioelements");
-  MixPresentationRepository mixPresentationRepository_ =
-      juce::ValueTree("mixPresentation");
+  ChannelMonitorData channelMonitorData;
 
   // temporary hard-code for testing purposes
   juce::Uuid presentationUuid = juce::Uuid();
   MixPresentation presentation(presentationUuid, "English Mix", 1,
                                LanguageData::MixLanguages::English, {});
 
-  juce::Uuid element = juce::Uuid();
-  presentation.addAudioElement(element, 1, "AE1");
-
-  AudioElement audioElement =
-      AudioElement(element, "Audio Element 1", Speakers::k7Point1Point4, 2);
-  audioElementRepository_.add(audioElement);
-
-  juce::Uuid elementa = juce::Uuid();
-  presentation.addAudioElement(elementa, 2, "AE2");
-  mixPresentationRepository_.add(presentation);
-
-  SpeakerMonitorData data;
-
-  ChannelMonitorProcessor channelMonitorProcessor;
+  ChannelMonitorProcessor channelMonitorProcessor(channelMonitorData);
 
   // Check if the gains are being applied correctly
   // Create an AudioBuffer to test the processBlock function
@@ -63,8 +48,11 @@ TEST(test_channelmonitor_processor, test_getPrerdrLoudness) {
   channelMonitorProcessor.prepareToPlay(2, numSamples);
   channelMonitorProcessor.processBlock(testDataBuffer, midiBuffer);
 
+  std::vector<float> channelLoudnessesRead;
+  channelMonitorData.channelLoudnesses.read(channelLoudnessesRead);
+
   for (int i = 0; i < 28; i++) {
     // Channels with value 0.5 have a rough dB value of -6
-    ASSERT_NEAR(channelMonitorProcessor.getPrerdrLoudness()[i], -6.0f, 0.1);
+    ASSERT_NEAR(channelLoudnessesRead[i], -6.0f, 0.1);
   }
 }

--- a/common/processors/tests/ChannelMonitorProcessor_test.cpp
+++ b/common/processors/tests/ChannelMonitorProcessor_test.cpp
@@ -24,12 +24,20 @@
 TEST(test_channelmonitor_processor, test_getPrerdrLoudness) {
   ChannelMonitorData channelMonitorData;
 
+  MixPresentationRepository mixPresentationRepository_ =
+      juce::ValueTree("mixPresentation");
+
+  MixPresentationSoloMuteRepository mixPresentationSoloMuteRepository_ =
+      juce::ValueTree("mixPresentationSoloMute");
+
   // temporary hard-code for testing purposes
   juce::Uuid presentationUuid = juce::Uuid();
   MixPresentation presentation(presentationUuid, "English Mix", 1,
                                LanguageData::MixLanguages::English, {});
 
-  ChannelMonitorProcessor channelMonitorProcessor(channelMonitorData);
+  ChannelMonitorProcessor channelMonitorProcessor(
+      channelMonitorData, &mixPresentationRepository_,
+      &mixPresentationSoloMuteRepository_);
 
   // Check if the gains are being applied correctly
   // Create an AudioBuffer to test the processBlock function

--- a/rendererplugin/src/RendererEditor.cpp
+++ b/rendererplugin/src/RendererEditor.cpp
@@ -63,10 +63,10 @@ void CustomLookAndFeel::drawButtonBackground(
 RendererEditor::RendererEditor(RendererProcessor& p)
     : MainEditor(p),
       dawWarningBanner_(&p.getRoomSetupRepository()),
-      currentScreen_(&monitorScreen_),
       monitorScreen_(p.getRepositories(), p.getSpeakerMonitorData(), *this,
                      p.getChannelMonitorProcessor(),
-                     p.getMainBusNumInputChannels()) {
+                     p.getMainBusNumInputChannels()),
+      currentScreen_(&monitorScreen_) {
   setResizable(true, true);
   setSize(1600, 752);
 

--- a/rendererplugin/src/RendererEditor.cpp
+++ b/rendererplugin/src/RendererEditor.cpp
@@ -63,8 +63,8 @@ void CustomLookAndFeel::drawButtonBackground(
 RendererEditor::RendererEditor(RendererProcessor& p)
     : MainEditor(p),
       dawWarningBanner_(&p.getRoomSetupRepository()),
-      monitorScreen_(p.getRepositories(), p.getSpeakerMonitorData(), *this,
-                     p.getChannelMonitorProcessor(),
+      monitorScreen_(p.getRepositories(), p.getSpeakerMonitorData(),
+                     p.getChannelMonitorData(), *this,
                      p.getMainBusNumInputChannels()),
       currentScreen_(&monitorScreen_) {
   setResizable(true, true);

--- a/rendererplugin/src/RendererEditor.h
+++ b/rendererplugin/src/RendererEditor.h
@@ -50,9 +50,8 @@ class RendererEditor final : public MainEditor {
 
   juce::Label titleLabel_;
   DAWWarningBanner dawWarningBanner_;
-  juce::Component* currentScreen_;
-
   MonitorScreen monitorScreen_;
+  juce::Component* currentScreen_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RendererEditor)
 };

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -69,9 +69,8 @@ RendererProcessor::RendererProcessor()
         fileExportRepository_, audioElementRepository_,
         mixPresentationRepository_, mixPresentationLoudnessRepository_));
   }
-  audioProcessors_.push_back(std::make_unique<ChannelMonitorProcessor>());
-  channelMonitorProcessor_ =
-      static_cast<ChannelMonitorProcessor*>(audioProcessors_.back().get());
+  audioProcessors_.push_back(
+      std::make_unique<ChannelMonitorProcessor>(channelMonitorData_));
   audioProcessors_.push_back(std::make_unique<RenderProcessor>(
       this, &roomSetupRepository_, &audioElementRepository_,
       &mixPresentationRepository_, &activeMixPresentationRepository_,

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -239,6 +239,8 @@ void RendererProcessor::setStateInformation(const void* data, int sizeInBytes) {
 
   updateRepositories();
 
+  initializeMixPresentations();
+
   configureOutputBus();
 
   if (juce::PluginHostType().isPremiere()) {
@@ -277,6 +279,13 @@ void RendererProcessor::updateRepositories() {
       persistentState_.getChildWithName(kMixPresentationsKey);
   if (mixPresentations.isValid()) {
     mixPresentationRepository_.setStateTree(mixPresentations);
+    LOG_ANALYTICS(instanceId_,
+                  "setStateInformation: Mix Presentations was successfully "
+                  "loaded from persistent state.");
+  } else {
+    LOG_ANALYTICS(instanceId_,
+                  "setStateInformation: Mix Presentation tree invalid or no "
+                  "Mix Presentations found.");
   }
 
   juce::ValueTree mixPresentationLoudness =
@@ -302,8 +311,6 @@ void RendererProcessor::updateRepositories() {
   if (fileExport.isValid()) {
     fileExportRepository_.setStateTree(fileExport);
   }
-
-  initializeMixPresentations();
 }
 
 juce::ValueTree RendererProcessor::getTreeWithId(const juce::Identifier& id) {
@@ -365,9 +372,11 @@ void RendererProcessor::initializeMixPresentations() {
     MixPresentation mixPres(juce::Uuid(), "My Mix Presentation", 1);
     mixPresentationRepository_.add(mixPres);
     activeMixPresentationRepository_.update(mixPres.getId());
-    LOG_ANALYTICS(instanceId_,
-                  "setStateInformation: Created a new mix presentation and set "
-                  "it as active.");
+    LOG_ANALYTICS(
+        instanceId_,
+        "setStateInformation: Created a new mix presentation w/ Uuid " +
+            mixPres.getId().toString().toStdString() +
+            " and set it as active.");
     return;  // Early return since we just set a valid active mix
   }
 

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -69,8 +69,9 @@ RendererProcessor::RendererProcessor()
         fileExportRepository_, audioElementRepository_,
         mixPresentationRepository_, mixPresentationLoudnessRepository_));
   }
-  audioProcessors_.push_back(
-      std::make_unique<ChannelMonitorProcessor>(channelMonitorData_));
+  audioProcessors_.push_back(std::make_unique<ChannelMonitorProcessor>(
+      channelMonitorData_, &mixPresentationRepository_,
+      &mixPresentationSoloMuteRepository_));
   audioProcessors_.push_back(std::make_unique<RenderProcessor>(
       this, &roomSetupRepository_, &audioElementRepository_,
       &mixPresentationRepository_, &activeMixPresentationRepository_,

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -153,6 +153,12 @@ void RendererProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
     proc->prepareToPlay(sampleRate, samplesPerBlock);
   }
   processingBuffer_.setSize(getMainBusNumInputChannels(), samplesPerBlock);
+  LOG_ANALYTICS(instanceId_, "activeMixPresentation Uuid: " +
+                                 activeMixPresentationRepository_.get()
+                                     .getActiveMixId()
+                                     .toString()
+                                     .toStdString() +
+                                 "\n");
 }
 
 void RendererProcessor::releaseResources() {
@@ -246,6 +252,13 @@ void RendererProcessor::setStateInformation(const void* data, int sizeInBytes) {
       setNonRealtime(true);
     }
   }
+
+  LOG_ANALYTICS(instanceId_, "activeMixPresentation Uuid: " +
+                                 activeMixPresentationRepository_.get()
+                                     .getActiveMixId()
+                                     .toString()
+                                     .toStdString() +
+                                 "\n");
 }
 
 void RendererProcessor::updateRepositories() {

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -277,15 +277,22 @@ void RendererProcessor::updateRepositories() {
 
   juce::ValueTree mixPresentations =
       persistentState_.getChildWithName(kMixPresentationsKey);
+  int mixPresCount = mixPresentations.getNumChildren();
   if (mixPresentations.isValid()) {
     mixPresentationRepository_.setStateTree(mixPresentations);
     LOG_ANALYTICS(instanceId_,
                   "setStateInformation: Mix Presentations was successfully "
                   "loaded from persistent state.");
+    LOG_ANALYTICS(
+        instanceId_,
+        "The Number of Mix Presentations found in the persistent state was: " +
+            std::to_string(mixPresCount));
   } else {
     LOG_ANALYTICS(instanceId_,
                   "setStateInformation: Mix Presentation tree invalid or no "
-                  "Mix Presentations found.");
+                  "Mix Presentations found. There are currently " +
+                      std::to_string(mixPresCount) +
+                      " Mix Presentations in the repository.");
   }
 
   juce::ValueTree mixPresentationLoudness =
@@ -366,17 +373,26 @@ void RendererProcessor::valueTreeChildRemoved(
 }
 
 void RendererProcessor::initializeMixPresentations() {
+  juce::ValueTree mixPresTree =
+      persistentState_.getChildWithName(kMixPresentationsKey);
+  int mixPresCount = mixPresTree.getNumChildren();
+  LOG_ANALYTICS(instanceId_,
+                "Initializing MixPresentations. The Number of Mix "
+                "Presentations found in the persistent state was: " +
+                    std::to_string(mixPresCount));
+
   juce::OwnedArray<MixPresentation> mixPresentations;
   mixPresentationRepository_.getAll(mixPresentations);
+
   if (mixPresentations.size() == 0) {
     MixPresentation mixPres(juce::Uuid(), "My Mix Presentation", 1);
     mixPresentationRepository_.add(mixPres);
     activeMixPresentationRepository_.update(mixPres.getId());
-    LOG_ANALYTICS(
-        instanceId_,
-        "setStateInformation: Created a new mix presentation w/ Uuid " +
-            mixPres.getId().toString().toStdString() +
-            " and set it as active.");
+    LOG_ANALYTICS(instanceId_,
+                  "setStateInformation: MixPresentationRepo was empty. Created "
+                  "a new mix presentation w/ Uuid " +
+                      mixPres.getId().toString().toStdString() +
+                      " and set it as active.");
     return;  // Early return since we just set a valid active mix
   }
 

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -318,6 +318,24 @@ void RendererProcessor::updateRepositories() {
   if (fileExport.isValid()) {
     fileExportRepository_.setStateTree(fileExport);
   }
+
+  juce::ValueTree channelGains =
+      persistentState_.getChildWithName(kMultiChannelGainsKey);
+  if (channelGains.isValid()) {
+    multichannelgainRepository_.setStateTree(channelGains);
+  }
+
+  juce::ValueTree muteSoloPlayback =
+      persistentState_.getChildWithName(kMSPlaybackKey);
+  if (muteSoloPlayback.isValid()) {
+    msPlaybackRepository_.setStateTree(muteSoloPlayback);
+  }
+
+  juce::ValueTree mixPresMuteSolo =
+      persistentState_.getChildWithName(kMixPresentationSoloMuteKey);
+  if (mixPresMuteSolo.isValid()) {
+    mixPresentationSoloMuteRepository_.setStateTree(mixPresMuteSolo);
+  }
 }
 
 juce::ValueTree RendererProcessor::getTreeWithId(const juce::Identifier& id) {

--- a/rendererplugin/src/RendererProcessor.h
+++ b/rendererplugin/src/RendererProcessor.h
@@ -28,6 +28,7 @@
 #include "data_repository/implementation/MixPresentationSoloMuteRepository.h"
 #include "data_repository/implementation/RoomSetupRepository.h"
 #include "data_structures/src/AudioElementCommunication.h"
+#include "data_structures/src/ChannelMonitorData.h"
 #include "data_structures/src/RepositoryCollection.h"
 #include "processors/processor_base/ProcessorBase.h"
 
@@ -93,6 +94,7 @@ class RendererProcessor final : public ProcessorBase,
 
   RoomSetupRepository& getRoomSetupRepository() { return roomSetupRepository_; }
   SpeakerMonitorData& getSpeakerMonitorData() { return monitorData_; }
+  ChannelMonitorData& getChannelMonitorData() { return channelMonitorData_; }
 
   void updateAudioElementPluginInformation(
       AudioElementSpatialLayout& audioElementSpatialLayout) override {
@@ -102,10 +104,6 @@ class RendererProcessor final : public ProcessorBase,
   void removeAudioElementPlugin(
       AudioElementSpatialLayout& audioElementSpatialLayout) override {
     audioElementSpatialLayoutRepository_.remove(audioElementSpatialLayout);
-  }
-
-  ChannelMonitorProcessor* getChannelMonitorProcessor() const {
-    return channelMonitorProcessor_;
   }
 
  private:
@@ -166,7 +164,7 @@ class RendererProcessor final : public ProcessorBase,
 
   SpeakerMonitorData monitorData_;
 
-  ChannelMonitorProcessor* channelMonitorProcessor_;
+  ChannelMonitorData channelMonitorData_;
 
   juce::AudioChannelSet outputChannelSet_ = juce::AudioChannelSet::stereo();
 

--- a/rendererplugin/src/screens/EditPresentationScreen.cpp
+++ b/rendererplugin/src/screens/EditPresentationScreen.cpp
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 
+#include "../RendererProcessor.h"
 #include "MixPresentationTagScreen.h"
 #include "components/src/EclipsaColours.h"
 #include "data_repository/implementation/MixPresentationRepository.h"

--- a/rendererplugin/src/screens/EditPresentationScreen.h
+++ b/rendererplugin/src/screens/EditPresentationScreen.h
@@ -17,12 +17,9 @@
 #pragma once
 #include <components/components.h>
 
-#include "../RendererProcessor.h"
 #include "MixPresentationTagScreen.h"
 #include "components/src/MainEditor.h"
 #include "data_repository/implementation/MixPresentationRepository.h"
-#include "logger/logger.h"
-#include "mix_tabs/PresentationEditorTab.h"
 
 class EditPresentationScreenLookAndFeel : public juce::LookAndFeel_V4 {
  public:

--- a/rendererplugin/src/screens/MonitorScreen.h
+++ b/rendererplugin/src/screens/MonitorScreen.h
@@ -20,24 +20,24 @@
 #include "MixMonitoringScreen.h"
 #include "PresentationMonitorScreen.h"
 #include "RoomMonitoringScreen.h"
+#include "data_structures/src/ChannelMonitorData.h"
+#include "data_structures/src/RepositoryCollection.h"
 
 class MonitorScreen : public juce::Component {
+  RepositoryCollection repos_;
   PresentationMonitorScreen presentationMonitorScreen_;
   RoomMonitoringScreen roomMonitoringScreen_;
   MixMonitoringScreen mixMonitoringScreen_;
 
  public:
   MonitorScreen(RepositoryCollection repos, SpeakerMonitorData& data,
-                MainEditor& editor,
-                ChannelMonitorProcessor* channelMonitorProcessor,
+                ChannelMonitorData& channelMonitorData, MainEditor& editor,
                 int totalChannelCount)
-      : presentationMonitorScreen_(
-            editor, &repos.aeRepo_, &repos.audioElementSpatialLayoutRepo_,
-            &repos.mpRepo_, &repos.mpSMRepo_, &repos.chGainRepo_,
-            &repos.activeMPRepo_, channelMonitorProcessor, &repos.fioRepo_,
-            totalChannelCount),
-        roomMonitoringScreen_(repos, data, editor),
-        mixMonitoringScreen_(repos, data) {}
+      : repos_(repos),
+        presentationMonitorScreen_(editor, repos_, channelMonitorData,
+                                   totalChannelCount),
+        roomMonitoringScreen_(repos_, data, editor),
+        mixMonitoringScreen_(repos_, data) {}
 
   void paint(juce::Graphics& g) {
     auto bounds = getLocalBounds();

--- a/rendererplugin/src/screens/PresentationMonitorScreen.cpp
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.cpp
@@ -232,6 +232,8 @@ void PresentationMonitorScreen::updatePresentationTabs() {
   // Get the ID of the active mix presentation.
   juce::Uuid activeMixID = activeMixRepository_->get().getActiveMixId();
   if (activeMixID != juce::Uuid::null()) {
+    LOG_ANALYTICS(0, "Active mix presentation ID: " +
+                         activeMixID.toString().toStdString());
     // Check there exists a tab with the active mix presentation ID.
     for (int i = 0; i < presentationTabs_->getNumTabs(); ++i) {
       MixPresentationViewPort* tab = static_cast<MixPresentationViewPort*>(
@@ -247,6 +249,11 @@ void PresentationMonitorScreen::updatePresentationTabs() {
   // active mix presentation to the last tab and select it.
   else {
     presentationTabs_->setCurrentTabIndex(presentationTabs_->getNumTabs() - 1);
+    MixPresentationViewPort* tab = static_cast<MixPresentationViewPort*>(
+        presentationTabs_->getCurrentContentComponent());
+    juce::Uuid chosenActiveMixID = tab->getMixPresID();
+    LOG_ANALYTICS(0, "No Active mix presentation ID found, so setting it to: " +
+                         chosenActiveMixID.toString().toStdString());
   }
   LOG_ANALYTICS(RendererProcessor::instanceId_,
                 "All presentation tabs updated.");

--- a/rendererplugin/src/screens/PresentationMonitorScreen.cpp
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.cpp
@@ -185,16 +185,6 @@ void PresentationMonitorScreen::updateMixPresentations() {
 
   numMixes_ = mixPresentationArray_.size();
 
-  // address the case where there is just 1 mix presentation on start up
-  // that is added before this component is added as a listener
-  // manually add the mixPresentationID to MixPresentataionSoloMuteRepository
-  juce::OwnedArray<MixPresentationSoloMute> mixPresSoloMuteArray;
-  mixPresentationSoloMuteRepository_->getAll(mixPresSoloMuteArray);
-  if (numMixes_ == 1 && mixPresSoloMuteArray.isEmpty()) {
-    MixPresentationSoloMute mixPresentationSoloMute(
-        mixPresentationArray_[0]->getId(), mixPresentationArray_[0]->getName());
-    mixPresentationSoloMuteRepository_->add(mixPresentationSoloMute);
-  }
   LOG_ANALYTICS(
       RendererProcessor::instanceId_,
       "Mix presentations updated. Total mixes: " + std::to_string(numMixes_));
@@ -264,12 +254,6 @@ void PresentationMonitorScreen::valueTreeChildAdded(
             channelMonitorData_),
         true);
 
-    MixPresentationSoloMute mixPresentationSoloMute(
-        juce::Uuid(childWhichHasBeenAdded[MixPresentationSoloMute::kId]),
-        childWhichHasBeenAdded[MixPresentationSoloMute::kName]);
-
-    mixPresentationSoloMuteRepository_->updateOrAdd(mixPresentationSoloMute);
-
     // repaint the tabs/presentation screen
     repaint(presentationTabBounds_);
   } else if (parentTree.getType() == MixPresentation::kTreeType) {
@@ -285,13 +269,6 @@ void PresentationMonitorScreen::valueTreeChildAdded(
         break;
       }
     }
-    // update the name in the solo mute repo as well
-    MixPresentationSoloMute mixPresSoloMute =
-        mixPresentationSoloMuteRepository_->get(mixPresId).value_or(
-            MixPresentationSoloMute());
-    mixPresSoloMute.setName(
-        parentTree[MixPresentation::kPresentationName].toString());
-    mixPresentationSoloMuteRepository_->update(mixPresSoloMute);
   }
 }
 
@@ -315,13 +292,6 @@ void PresentationMonitorScreen::valueTreeChildRemoved(
 
     // update the tab button bounds
     updateTabButtonBounds(presentationTabBounds_);
-    // if a mix presentation is removed, remove it from the mpSM repository
-    // this includes removing the audio elements
-    MixPresentationSoloMute mixPresentationSoloMute(
-        juce::Uuid(childWhichHasBeenRemoved[MixPresentationSoloMute::kId]),
-        childWhichHasBeenRemoved[MixPresentationSoloMute::kName]);
-
-    mixPresentationSoloMuteRepository_->remove(mixPresentationSoloMute);
   }
   // repaint the tabs/presentation screen
   repaint(presentationTabBounds_);

--- a/rendererplugin/src/screens/PresentationMonitorScreen.h
+++ b/rendererplugin/src/screens/PresentationMonitorScreen.h
@@ -19,9 +19,10 @@
 #include "ElementRoutingScreen.h"
 #include "components/src/ImageTextButton.h"  // Include the ImageTextButton header
 #include "data_repository/implementation/AudioElementRepository.h"
-#include "data_repository/implementation/FileExportRepository.h"
 #include "data_repository/implementation/MixPresentationSoloMuteRepository.h"
+#include "data_structures/src/ChannelMonitorData.h"
 #include "data_structures/src/MixPresentation.h"
+#include "data_structures/src/RepositoryCollection.h"
 #include "mix_tabs/MixPresentationViewPort.h"
 
 class CustomTabbedComponent : public juce::TabbedComponent {
@@ -53,16 +54,9 @@ class PresentationMonitorScreen : public juce::Component,
   EditPresentationScreen editPresentationScreen_;
 
  public:
-  PresentationMonitorScreen(
-      MainEditor& editor, AudioElementRepository* ae_repository,
-      MultibaseAudioElementSpatialLayoutRepository*
-          audioElementSpatialLayout_repository,
-      MixPresentationRepository* mixPresentationRepository,
-      MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository,
-      MultiChannelRepository* multiChannelRepository,
-      ActiveMixRepository* activeMixRepo,
-      ChannelMonitorProcessor* channelMonitorProcessor,
-      FileExportRepository* fileExportRepository, int totalChannelCount);
+  PresentationMonitorScreen(MainEditor& editor, RepositoryCollection repos,
+                            ChannelMonitorData& channelMonitorData,
+                            int totalChannelCount);
 
   ~PresentationMonitorScreen();
 
@@ -88,14 +82,15 @@ class PresentationMonitorScreen : public juce::Component,
   int initialTabIndex_;
   juce::Rectangle<int> presentationTabBounds_ =
       juce::Rectangle<int>(0, 0, 0, 0);
+  RepositoryCollection repos_;
   MixPresentationRepository* mixPresentationRepository_;
   MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository_;
   AudioElementRepository* audioElementRepository_;
   ActiveMixRepository* activeMixRepository_;
   MultiChannelRepository* multiChannelRepository_;
+  ChannelMonitorData& channelMonitorData_;
 
   juce::OwnedArray<MixPresentation> mixPresentationArray_;
   int numMixes_ = 0;
   std::unique_ptr<CustomTabbedComponent> presentationTabs_;
-  ChannelMonitorProcessor* channelMonitorProcessor_;
 };

--- a/rendererplugin/src/screens/mix_tabs/MixPresentationViewPort.cpp
+++ b/rendererplugin/src/screens/mix_tabs/MixPresentationViewPort.cpp
@@ -26,7 +26,7 @@ MixPresentationViewPort::MixPresentationViewPort(
   viewPort_.setScrollBarsShown(true, false);
 }
 
-MixPresentationViewPort::~MixPresentationViewPort(){};
+MixPresentationViewPort::~MixPresentationViewPort() {};
 
 void MixPresentationViewPort::paint(juce::Graphics& g) {
   const auto bounds = getLocalBounds();

--- a/rendererplugin/src/screens/mix_tabs/MixPresentationViewPort.cpp
+++ b/rendererplugin/src/screens/mix_tabs/MixPresentationViewPort.cpp
@@ -15,24 +15,18 @@
 #include "MixPresentationViewPort.h"
 
 MixPresentationViewPort::MixPresentationViewPort(
-    const juce::Uuid mixPresID, AudioElementRepository* aeRepository,
-    MultiChannelRepository* multichannelGainRepo,
-    ActiveMixRepository* activeMixRepo,
-    ChannelMonitorProcessor* channelMonitorProcessor,
-    MixPresentationRepository* mixPresentationRepository,
-    MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository)
+    const juce::Uuid mixPresID, RepositoryCollection repos,
+    ChannelMonitorData& channelMonitorData)
     : kmixPresID_(mixPresID),
-      mixPresentationRepository_(mixPresentationRepository),
-      mixPresentationSoloMuteRepository_(mixPresentationSoloMuteRepository),
-      tab_(mixPresID, aeRepository, multichannelGainRepo, activeMixRepo,
-           channelMonitorProcessor, mixPresentationRepository,
-           mixPresentationSoloMuteRepository) {
+      mixPresentationRepository_(&repos.mpRepo_),
+      mixPresentationSoloMuteRepository_(&repos.mpSMRepo_),
+      tab_(mixPresID, repos, channelMonitorData) {
   addAndMakeVisible(viewPort_);
   viewPort_.setViewedComponent(&tab_);
   viewPort_.setScrollBarsShown(true, false);
 }
 
-MixPresentationViewPort::~MixPresentationViewPort() {};
+MixPresentationViewPort::~MixPresentationViewPort(){};
 
 void MixPresentationViewPort::paint(juce::Graphics& g) {
   const auto bounds = getLocalBounds();

--- a/rendererplugin/src/screens/mix_tabs/MixPresentationViewPort.h
+++ b/rendererplugin/src/screens/mix_tabs/MixPresentationViewPort.h
@@ -17,16 +17,14 @@
 #include "PresentationTab.h"
 #include "data_repository/implementation/MixPresentationRepository.h"
 #include "data_repository/implementation/MixPresentationSoloMuteRepository.h"
+#include "data_structures/src/ChannelMonitorData.h"
+#include "data_structures/src/RepositoryCollection.h"
 
 class MixPresentationViewPort : public juce::Component {
  public:
-  MixPresentationViewPort(
-      const juce::Uuid mixPresID, AudioElementRepository* aeRepository,
-      MultiChannelRepository* multichannelGainRepo,
-      ActiveMixRepository* activeMixRepo,
-      ChannelMonitorProcessor* channelMonitorProcessor,
-      MixPresentationRepository* mixPresentationRepository,
-      MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository);
+  MixPresentationViewPort(const juce::Uuid mixPresID,
+                          RepositoryCollection repos,
+                          ChannelMonitorData& channelMonitorData);
   ~MixPresentationViewPort();
 
   void paint(juce::Graphics& g) override;

--- a/rendererplugin/src/screens/mix_tabs/PresentationEditorTab.cpp
+++ b/rendererplugin/src/screens/mix_tabs/PresentationEditorTab.cpp
@@ -16,6 +16,7 @@
 
 #include <optional>
 
+#include "../../RendererProcessor.h"
 #include "data_structures/src/AudioElement.h"
 #include "data_structures/src/MixPresentation.h"
 #include "substream_rdr/substream_rdr_utils/Speakers.h"

--- a/rendererplugin/src/screens/mix_tabs/PresentationEditorTab.h
+++ b/rendererplugin/src/screens/mix_tabs/PresentationEditorTab.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "../../RendererProcessor.h"
 #include "PresentationEditorViewPort.h"
 #include "components/src/ControlKnobSkewed.h"
 #include "components/src/GainControlTextEditor.h"
@@ -25,7 +24,6 @@
 #include "components/src/SelectionBox.h"
 #include "data_repository/implementation/AudioElementRepository.h"
 #include "data_repository/implementation/MixPresentationRepository.h"
-#include "data_structures/src/MixPresentation.h"
 
 class PresentationEditorTabLookAndFeel : public juce::LookAndFeel_V4 {
  public:

--- a/rendererplugin/src/screens/mix_tabs/PresentationTab.cpp
+++ b/rendererplugin/src/screens/mix_tabs/PresentationTab.cpp
@@ -29,8 +29,7 @@ PresentationTab::PresentationTab(juce::Uuid mixPresID,
       multichannelGainRepo_(&repos.chGainRepo_),
       activeMixRepository_(&repos.activeMPRepo_),
       channelMonitorData_(channelMonitorData),
-      mixPresentationRepository_(&repos.mpRepo_),
-      mixPresentationSoloMuteRepository_(&repos.mpSMRepo_) {
+      mixPresentationRepository_(&repos.mpRepo_) {
   LOG_ANALYTICS(RendererProcessor::instanceId_,
                 "PresentationTab created for MixPresentation");
 
@@ -102,20 +101,6 @@ void PresentationTab::valueTreeChildAdded(
   if (parentTree.getType() == MixPresentation::kTreeType &&
       juce::Uuid(parentTree[MixPresentation::kId]) == kmixPresID_) {
     resetTab();
-
-    // add Audio Element to SoloMute Repository
-    MixPresentationSoloMute mixPresSoloMute =
-        mixPresentationSoloMuteRepository_->get(kmixPresID_)
-            .value_or(MixPresentationSoloMute());
-
-    for (auto audioElementNode : childWhichHasBeenAdded) {
-      mixPresSoloMute.addAudioElement(
-          juce::Uuid(audioElementNode[MixPresentationAudioElement::kId]),
-          audioElementNode[MixPresentationAudioElement::kReferenceId],
-          audioElementNode[MixPresentation::kPresentationName]);
-    }
-
-    mixPresentationSoloMuteRepository_->update(mixPresSoloMute);
   }
 }
 
@@ -125,18 +110,6 @@ void PresentationTab::valueTreeChildRemoved(
   if (childWhichHasBeenRemoved.getType() == MixPresentation::kAudioElements &&
       juce::Uuid(parentTree[MixPresentation::kId]) == kmixPresID_) {
     resetTab();
-
-    // remove Audio Element from SoloMute Repository
-    MixPresentationSoloMute mixPresSoloMute =
-        mixPresentationSoloMuteRepository_->get(kmixPresID_)
-            .value_or(MixPresentationSoloMute());
-
-    for (auto audioElementNode : childWhichHasBeenRemoved) {
-      mixPresSoloMute.removeAudioElement(
-          juce::Uuid(audioElementNode[MixPresentationAudioElement::kId]));
-    }
-
-    mixPresentationSoloMuteRepository_->update(mixPresSoloMute);
   }
 }
 

--- a/rendererplugin/src/screens/mix_tabs/PresentationTab.cpp
+++ b/rendererplugin/src/screens/mix_tabs/PresentationTab.cpp
@@ -17,25 +17,20 @@
 #include <cstddef>
 #include <optional>
 
-#include "data_repository/implementation/MixPresentationRepository.h"
-#include "data_structures/src/AudioElement.h"
-#include "data_structures/src/MixPresentation.h"
-#include "data_structures/src/MixPresentationSoloMute.h"
+#include "data_structures/src/ChannelMonitorData.h"
+#include "data_structures/src/RepositoryCollection.h"
 
-PresentationTab::PresentationTab(
-    juce::Uuid mixPresID, AudioElementRepository* aeRepository,
-    MultiChannelRepository* multichannelGainRepo,
-    ActiveMixRepository* activeMixRepo,
-    ChannelMonitorProcessor* channelMonitorProcessor,
-    MixPresentationRepository* mixPresentationRepository,
-    MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository)
-    : audioElementRepository_(aeRepository),
+PresentationTab::PresentationTab(juce::Uuid mixPresID,
+                                 RepositoryCollection repos,
+                                 ChannelMonitorData& channelMonitorData)
+    : repos_(repos),
+      audioElementRepository_(&repos.aeRepo_),
       kmixPresID_(mixPresID),
-      multichannelGainRepo_(multichannelGainRepo),
-      activeMixRepository_(activeMixRepo),
-      channelMonitorProcessor_(channelMonitorProcessor),
-      mixPresentationRepository_(mixPresentationRepository),
-      mixPresentationSoloMuteRepository_(mixPresentationSoloMuteRepository) {
+      multichannelGainRepo_(&repos.chGainRepo_),
+      activeMixRepository_(&repos.activeMPRepo_),
+      channelMonitorData_(channelMonitorData),
+      mixPresentationRepository_(&repos.mpRepo_),
+      mixPresentationSoloMuteRepository_(&repos.mpSMRepo_) {
   LOG_ANALYTICS(RendererProcessor::instanceId_,
                 "PresentationTab created for MixPresentation");
 
@@ -199,10 +194,8 @@ void PresentationTab::createAEStrips() {
     int first_channel = audioelement.getFirstChannel();
     juce::String label_text = audioelement.getName();
     aeStrips_.add(std::make_unique<AEStripComponent>(
-        channel_count, label_text, first_channel, multichannelGainRepo_,
-        channelMonitorProcessor_, mixpresentationAudioElements_[i].getId(),
-        kmixPresID_, mixPresentationRepository_,
-        mixPresentationSoloMuteRepository_));
+        channel_count, label_text, first_channel, repos_, channelMonitorData_,
+        mixpresentationAudioElements_[i].getId(), kmixPresID_));
     addAndMakeVisible(aeStrips_.getLast());
   }
 

--- a/rendererplugin/src/screens/mix_tabs/PresentationTab.cpp
+++ b/rendererplugin/src/screens/mix_tabs/PresentationTab.cpp
@@ -29,7 +29,8 @@ PresentationTab::PresentationTab(juce::Uuid mixPresID,
       multichannelGainRepo_(&repos.chGainRepo_),
       activeMixRepository_(&repos.activeMPRepo_),
       channelMonitorData_(channelMonitorData),
-      mixPresentationRepository_(&repos.mpRepo_) {
+      mixPresentationRepository_(&repos.mpRepo_),
+      mixPresentationSoloMuteRepository_(&repos.mpSMRepo_) {
   LOG_ANALYTICS(RendererProcessor::instanceId_,
                 "PresentationTab created for MixPresentation");
 

--- a/rendererplugin/src/screens/mix_tabs/PresentationTab.h
+++ b/rendererplugin/src/screens/mix_tabs/PresentationTab.h
@@ -114,7 +114,6 @@ class PresentationTab : public juce::Component,
   AudioElementRepository* audioElementRepository_;
   ActiveMixRepository* activeMixRepository_;
   MixPresentationRepository* mixPresentationRepository_;
-  MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository_;
   juce::OwnedArray<AudioElement> allAudioElementsArray_;  // all audio elements
   std::vector<AudioElement>
       audioElements_;  // the audio elements that belong to this mix

--- a/rendererplugin/src/screens/mix_tabs/PresentationTab.h
+++ b/rendererplugin/src/screens/mix_tabs/PresentationTab.h
@@ -114,6 +114,7 @@ class PresentationTab : public juce::Component,
   AudioElementRepository* audioElementRepository_;
   ActiveMixRepository* activeMixRepository_;
   MixPresentationRepository* mixPresentationRepository_;
+  MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository_;
   juce::OwnedArray<AudioElement> allAudioElementsArray_;  // all audio elements
   std::vector<AudioElement>
       audioElements_;  // the audio elements that belong to this mix

--- a/rendererplugin/src/screens/mix_tabs/PresentationTab.h
+++ b/rendererplugin/src/screens/mix_tabs/PresentationTab.h
@@ -19,21 +19,17 @@
 #include "../../RendererProcessor.h"
 #include "components/src/AEStripComponent.h"
 #include "data_repository/implementation/MixPresentationRepository.h"
+#include "data_structures/src/ChannelMonitorData.h"
 #include "data_structures/src/MixPresentation.h"
 #include "data_structures/src/MixPresentationSoloMute.h"
+#include "data_structures/src/RepositoryCollection.h"
 #include "logger/logger.h"
-#include "substream_rdr/substream_rdr_utils/Speakers.h"
 
 class PresentationTab : public juce::Component,
                         public juce::ValueTree::Listener {
  public:
-  PresentationTab(
-      juce::Uuid mixPresID, AudioElementRepository* aeRepository,
-      MultiChannelRepository* multichannelGainRepo,
-      ActiveMixRepository* activeMixRepo,
-      ChannelMonitorProcessor* channelMonitorProcessor,
-      MixPresentationRepository* mixPresentationRepository,
-      MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository);
+  PresentationTab(juce::Uuid mixPresID, RepositoryCollection repos,
+                  ChannelMonitorData& channelMonitorData);
 
   ~PresentationTab() override;
 
@@ -114,6 +110,7 @@ class PresentationTab : public juce::Component,
 
   const juce::Uuid kmixPresID_;
 
+  RepositoryCollection repos_;
   AudioElementRepository* audioElementRepository_;
   ActiveMixRepository* activeMixRepository_;
   MixPresentationRepository* mixPresentationRepository_;
@@ -124,7 +121,7 @@ class PresentationTab : public juce::Component,
   std::vector<MixPresentationAudioElement> mixpresentationAudioElements_;
 
   MultiChannelRepository* multichannelGainRepo_;
-  ChannelMonitorProcessor* channelMonitorProcessor_;
+  ChannelMonitorData& channelMonitorData_;
   juce::OwnedArray<AEStripComponent> aeStrips_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PresentationTab)


### PR DESCRIPTION
### Description
The ChannelMonitorProcessor was being passed as a reference to Front-End Components, which lead to an awkward dependance between front end and back end components. A Real-time data struct was implemented for storing channel loudness calculations and passed as a reference to the PresentationMonitorScreen/AEStripComponents. Also made the ChannelMonitorProcessor handle listener callbacks for the MixPresentation and MixPresentationSoloMute Repositories.

### Changes
Moved Listener Callbacks that update the MixPresentationSoloMuteRepository from the PresentationMonitorScreen and PresentationTab to the ChannelMonitorProcessor.
Created the ChannelMonitorData data struct for storing real time loudness calculations for each audio element's channels.
Rewrote the constructors of various UI components to be more concise by using the RepositoryCollection

### Validation and Acceptance Criteria
- [ ] Ensured all unit tests pass
- [ ] Ensured FileExport was successful within REAPER, juce::PluginHost, ProTools and PremierePro
- [ ] Ensured that FileExport Loudness meta data sensibly changed with MixPresentation gain being adjusted
