### PR TITLE
Test playback

### DIFF
--- a/audioelementplugin/src/AudioElementPluginProcessor.cpp
+++ b/audioelementplugin/src/AudioElementPluginProcessor.cpp
@@ -271,19 +271,21 @@ void AudioElementPluginProcessor::setStateInformation(const void* data,
     automationParametersTreeState.replaceState(automationTree);
   }
 
-  // after loading state, re-apply saved routing and notify renderer
+  // after restoring state, reapply routing and notify renderer
   {
-    // 1) apply output channel layout
-    AudioElementSpatialLayout layout = audioElementSpatialLayoutRepository_.get();
+    // apply output channel layout
+    AudioElementSpatialLayout layout =
+        audioElementSpatialLayoutRepository_.get();
     setOutputChannels(layout.getFirstChannel(),
                       layout.getChannelLayout().getNumChannels());
 
-    // 2) broadcast layout to renderer
+    // broadcast layout to renderer
     syncClient_.sendAudioElementSpatialLayoutRepository();
 
-    // 3) re-initialize routing processors
-    for (auto& proc : audioProcessors_)
+    // re-initialize routing processors
+    for (auto& proc : audioProcessors_) {
       if (auto* router = dynamic_cast<RoutingProcessor*>(proc.get()))
         router->initializeRouting();
+    }
   }
 }

--- a/audioelementplugin/src/AudioElementPluginProcessor.cpp
+++ b/audioelementplugin/src/AudioElementPluginProcessor.cpp
@@ -284,9 +284,8 @@ void AudioElementPluginProcessor::reinitializeAfterStateRestore() {
   // Broadcast layout to renderer
   syncClient_.sendAudioElementSpatialLayoutRepository();
 
-  // Re-initialize routing processors
+  // Re-initialize all child processors that require post-state setup
   for (auto& proc : audioProcessors_) {
-    if (auto* router = dynamic_cast<RoutingProcessor*>(proc.get()))
-      router->reinitializeAfterStateRestore();
+    proc->reinitializeAfterStateRestore();
   }
 }

--- a/audioelementplugin/src/AudioElementPluginProcessor.cpp
+++ b/audioelementplugin/src/AudioElementPluginProcessor.cpp
@@ -271,21 +271,22 @@ void AudioElementPluginProcessor::setStateInformation(const void* data,
     automationParametersTreeState.replaceState(automationTree);
   }
 
-  // after restoring state, reapply routing and notify renderer
-  {
-    // apply output channel layout
-    AudioElementSpatialLayout layout =
-        audioElementSpatialLayoutRepository_.get();
-    setOutputChannels(layout.getFirstChannel(),
-                      layout.getChannelLayout().getNumChannels());
+  // Re-initialize components after state restoration
+  reinitializeAfterStateRestore();
+}
 
-    // broadcast layout to renderer
-    syncClient_.sendAudioElementSpatialLayoutRepository();
+void AudioElementPluginProcessor::reinitializeAfterStateRestore() {
+  // Apply output channel layout
+  AudioElementSpatialLayout layout = audioElementSpatialLayoutRepository_.get();
+  setOutputChannels(layout.getFirstChannel(),
+                    layout.getChannelLayout().getNumChannels());
 
-    // re-initialize routing processors
-    for (auto& proc : audioProcessors_) {
-      if (auto* router = dynamic_cast<RoutingProcessor*>(proc.get()))
-        router->initializeRouting();
-    }
+  // Broadcast layout to renderer
+  syncClient_.sendAudioElementSpatialLayoutRepository();
+
+  // Re-initialize routing processors
+  for (auto& proc : audioProcessors_) {
+    if (auto* router = dynamic_cast<RoutingProcessor*>(proc.get()))
+      router->reinitializeAfterStateRestore();
   }
 }

--- a/audioelementplugin/src/AudioElementPluginProcessor.cpp
+++ b/audioelementplugin/src/AudioElementPluginProcessor.cpp
@@ -270,4 +270,20 @@ void AudioElementPluginProcessor::setStateInformation(const void* data,
   if (automationTree.isValid()) {
     automationParametersTreeState.replaceState(automationTree);
   }
+
+  // after loading state, re-apply saved routing and notify renderer
+  {
+    // 1) apply output channel layout
+    AudioElementSpatialLayout layout = audioElementSpatialLayoutRepository_.get();
+    setOutputChannels(layout.getFirstChannel(),
+                      layout.getChannelLayout().getNumChannels());
+
+    // 2) broadcast layout to renderer
+    syncClient_.sendAudioElementSpatialLayoutRepository();
+
+    // 3) re-initialize routing processors
+    for (auto& proc : audioProcessors_)
+      if (auto* router = dynamic_cast<RoutingProcessor*>(proc.get()))
+        router->initializeRouting();
+  }
 }

--- a/audioelementplugin/src/AudioElementPluginProcessor.h
+++ b/audioelementplugin/src/AudioElementPluginProcessor.h
@@ -88,6 +88,7 @@ class AudioElementPluginProcessor final : public ProcessorBase,
   }
 
   AudioElementParameterTree automationParametersTreeState;
+  void reinitializeAfterStateRestore() override;
 
   inline static const ::juce::Identifier
       kAudioElementSpatialLayoutRepositoryStateKey{
@@ -125,8 +126,6 @@ class AudioElementPluginProcessor final : public ProcessorBase,
   AudioElementPluginSyncClient syncClient_;
   SpeakerMonitorData monitorData_;
   AmbisonicsData ambisonicsData_;  // intiialized in SoundFieldProcessor
-
-  void reinitializeAfterStateRestore();
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioElementPluginProcessor)
 };

--- a/audioelementplugin/src/AudioElementPluginProcessor.h
+++ b/audioelementplugin/src/AudioElementPluginProcessor.h
@@ -126,5 +126,7 @@ class AudioElementPluginProcessor final : public ProcessorBase,
   SpeakerMonitorData monitorData_;
   AmbisonicsData ambisonicsData_;  // intiialized in SoundFieldProcessor
 
+  void reinitializeAfterStateRestore();
+
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioElementPluginProcessor)
 };

--- a/common/processors/processor_base/ProcessorBase.h
+++ b/common/processors/processor_base/ProcessorBase.h
@@ -67,6 +67,7 @@ class ProcessorBase : public juce::AudioProcessor {
   void setStateInformation(const void* data, int sizeInBytes) override {
     juce::ignoreUnused(data, sizeInBytes);
   }
+  virtual void reinitializeAfterStateRestore() {}
 
   juce::AudioProcessorEditor* createEditor() override { return nullptr; }
   bool hasEditor() const override { return false; }

--- a/common/processors/render/RenderProcessor.h
+++ b/common/processors/render/RenderProcessor.h
@@ -139,6 +139,7 @@ class RenderProcessor final : public ProcessorBase, juce::ValueTree::Listener {
 
  public:
   void initializeRenderers();
+
  private:
   void mixRenderedAudio(const bool mixFromBinaural, const int numSourceChannels,
                         juce::AudioBuffer<float>& outputBuffer);

--- a/common/processors/render/RenderProcessor.h
+++ b/common/processors/render/RenderProcessor.h
@@ -137,8 +137,9 @@ class RenderProcessor final : public ProcessorBase, juce::ValueTree::Listener {
 
   int getSpeakersOut() { return speakersOut_; }
 
- private:
+ public:
   void initializeRenderers();
+ private:
   void mixRenderedAudio(const bool mixFromBinaural, const int numSourceChannels,
                         juce::AudioBuffer<float>& outputBuffer);
   void updateBinauralLoudness(juce::AudioBuffer<float>& rdrdAudio);

--- a/common/processors/render/RenderProcessor.h
+++ b/common/processors/render/RenderProcessor.h
@@ -138,6 +138,9 @@ class RenderProcessor final : public ProcessorBase, juce::ValueTree::Listener {
   int getSpeakersOut() { return speakersOut_; }
 
  public:
+  void reinitializeAfterStateRestore() { initializeRenderers(); }
+
+ private:
   void initializeRenderers();
 
  private:

--- a/common/processors/routing/RoutingProcessor.h
+++ b/common/processors/routing/RoutingProcessor.h
@@ -71,6 +71,9 @@ class RoutingProcessor final : public ProcessorBase,
   //==============================================================================
 
  public:
+  void reinitializeAfterStateRestore() { initializeRouting(); }
+
+ private:
   void initializeRouting();
 
  private:

--- a/common/processors/routing/RoutingProcessor.h
+++ b/common/processors/routing/RoutingProcessor.h
@@ -70,8 +70,9 @@ class RoutingProcessor final : public ProcessorBase,
 
   //==============================================================================
 
- private:
+public:
   void initializeRouting();
+private:
 
   AudioElementSpatialLayoutRepository* audioElementSpatialLayoutData_;
   AudioElementPluginSyncClient* syncClient_;

--- a/common/processors/routing/RoutingProcessor.h
+++ b/common/processors/routing/RoutingProcessor.h
@@ -70,10 +70,10 @@ class RoutingProcessor final : public ProcessorBase,
 
   //==============================================================================
 
-public:
+ public:
   void initializeRouting();
-private:
 
+ private:
   AudioElementSpatialLayoutRepository* audioElementSpatialLayoutData_;
   AudioElementPluginSyncClient* syncClient_;
 

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -473,8 +473,8 @@ void RendererProcessor::reinitializeAfterStateRestore() {
   // Broadcast initial element list/layout to plugins after state load
   syncServer_.updateClients();
 
+  // Notify and reinitialize all child processors as needed
   for (auto& proc : audioProcessors_) {
-    if (auto* renderProc = dynamic_cast<RenderProcessor*>(proc.get()))
-      renderProc->reinitializeAfterStateRestore();
+    proc->reinitializeAfterStateRestore();
   }
 }

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -247,14 +247,7 @@ void RendererProcessor::setStateInformation(const void* data, int sizeInBytes) {
     }
   }
 
-  // broadcast initial element list/layout to plugins after state load
-  syncServer_.updateClients();
-
-  // rebuild RenderProcessor instances now that state is loaded
-  for (auto& proc : audioProcessors_) {
-    if (auto* renderProc = dynamic_cast<RenderProcessor*>(proc.get()))
-      renderProc->initializeRenderers();
-  }
+  reinitializeAfterStateRestore();
 }
 
 void RendererProcessor::updateRepositories() {
@@ -418,4 +411,14 @@ void RendererProcessor::configureOutputBus() {
   busesLayout.outputBuses.add(outputChannelSet_);
 
   setBusesLayout(busesLayout);
+}
+
+void RendererProcessor::reinitializeAfterStateRestore() {
+  // Broadcast initial element list/layout to plugins after state load
+  syncServer_.updateClients();
+
+  for (auto& proc : audioProcessors_) {
+    if (auto* renderProc = dynamic_cast<RenderProcessor*>(proc.get()))
+      renderProc->reinitializeAfterStateRestore();
+  }
 }

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -249,6 +249,12 @@ void RendererProcessor::setStateInformation(const void* data, int sizeInBytes) {
 
   // broadcast initial element list/layout to plugins after state load
   syncServer_.updateClients();
+
+  // rebuild RenderProcessor instances now that state is loaded
+  for (auto& proc : audioProcessors_) {
+    if (auto* renderProc = dynamic_cast<RenderProcessor*>(proc.get()))
+      renderProc->initializeRenderers();
+  }
 }
 
 void RendererProcessor::updateRepositories() {

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -246,6 +246,9 @@ void RendererProcessor::setStateInformation(const void* data, int sizeInBytes) {
       setNonRealtime(true);
     }
   }
+
+  // broadcast initial element list/layout to plugins after state load
+  syncServer_.updateClients();
 }
 
 void RendererProcessor::updateRepositories() {

--- a/rendererplugin/src/RendererProcessor.h
+++ b/rendererplugin/src/RendererProcessor.h
@@ -74,6 +74,10 @@ class RendererProcessor final : public ProcessorBase,
   void getStateInformation(juce::MemoryBlock& destData) override;
   void setStateInformation(const void* data, int sizeInBytes) override;
 
+ private:
+  void reinitializeAfterStateRestore();
+
+ public:
   juce::AudioProcessorEditor* getFileEditor() const;
   ProcessorBase* getFileOutputProcessor() const;
 

--- a/rendererplugin/src/RendererProcessor.h
+++ b/rendererplugin/src/RendererProcessor.h
@@ -74,9 +74,7 @@ class RendererProcessor final : public ProcessorBase,
   //==============================================================================
   void getStateInformation(juce::MemoryBlock& destData) override;
   void setStateInformation(const void* data, int sizeInBytes) override;
-
- private:
-  void reinitializeAfterStateRestore();
+  void reinitializeAfterStateRestore() override;
 
  public:
   juce::AudioProcessorEditor* getFileEditor() const;


### PR DESCRIPTION
### Description
Fixes ProTools-specific issue where saved sessions fail to play audio immediately after reopening until the Renderer plugin GUI is manually opened. This addresses a state synchronization gap between AudioElement and Renderer plugins during session restoration.

The fix implements immediate post-state-restoration synchronization to ensure all routing processors and renderer components are properly initialized. 

### Changes
Provide a summary of changes and their scope.

### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ] Saved ProTools sessions play audio immediately upon reopening without manual intervention
- [ ] Maintains compatibility across all supported DAWs (ProTools, Reaper, etc.)