### PR TITLE
GainRepository Persistance Bug

### DIFF
--- a/common/components/src/AEStripComponent.cpp
+++ b/common/components/src/AEStripComponent.cpp
@@ -360,10 +360,9 @@ void AEStripComponent::determineSoloMuteButtonColours() {
 void AEStripComponent::valueTreeChildAdded(
     juce::ValueTree& parentTree, juce::ValueTree& childWhichHasBeenAdded) {
   juce::Uuid parentID = juce::Uuid(parentTree[MixPresentationSoloMute::kId]);
-  juce::Uuid childID =
-      juce::Uuid(childWhichHasBeenAdded[MixPresentationSoloMute::kId]);
   juce::Uuid activeMixID = activeMixRepository_->get().getActiveMixId();
-  // if the parent tree is not the
+  // only update if the AE Strip belongs to the mix presentation that was
+  // changed or if the current mix presentation is the active mix
   if (parentID != mixPresID_ || parentID != activeMixID) {
     return;
   }

--- a/common/components/src/AEStripComponent.h
+++ b/common/components/src/AEStripComponent.h
@@ -23,6 +23,7 @@
 #include "data_repository/implementation/MixPresentationRepository.h"
 #include "data_repository/implementation/MixPresentationSoloMuteRepository.h"
 #include "data_repository/implementation/MultiChannelGainRepository.h"
+#include "data_structures/src/ActiveMixPresentation.h"
 #include "data_structures/src/ChannelMonitorData.h"
 #include "data_structures/src/RepositoryCollection.h"
 
@@ -125,6 +126,7 @@ class AEStripComponent : public juce::Component,
   MultiChannelRepository* multichannelGainRepo_;
   MixPresentationRepository* mixPresentationRepository_;
   MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository_;
+  ActiveMixRepository* activeMixRepository_;
 
   AEStripLookandFeel lookAndFeel_;
 

--- a/common/data_structures/src/MixPresentationSoloMute.cpp
+++ b/common/data_structures/src/MixPresentationSoloMute.cpp
@@ -15,7 +15,6 @@
 #include "MixPresentationSoloMute.h"
 
 #include "juce_core/system/juce_PlatformDefs.h"
-#include "logger/logger.h"
 
 MixPresentationSoloMute::MixPresentationSoloMute()
     : RepositoryItemBase(juce::Uuid::null()) {}

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -38,6 +38,7 @@ const juce::String GainProcessor::getName() const { return {"Gain"}; }
 
 //==============================================================================
 void GainProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
+  updateAllAudioParameterFloats();
   m_samplesPerBlock_ = samplesPerBlock;
   for (auto i = 0; i < channelGainsDSP_.size(); ++i) {
     channelGainsDSP_[i].prepare(

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -46,17 +46,6 @@ void GainProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
         {sampleRate, static_cast<uint32_t>(samplesPerBlock),
          static_cast<uint32_t>(channelGainsDSP_.size())});
   }
-  LOG_ANALYTICS(
-      0, "PrepareToPlay GainProcessor, gain repo: \n" +
-             channelGains_->get().toValueTree().toXmlString().toStdString());
-
-  std::string channelGainDSPsInfo = "Channel Gains DSPs:\n";
-  for (int i = 0; i < channelGainsDSP_.size(); i++) {
-    channelGainDSPsInfo +=
-        "Channel " + std::to_string(i) +
-        " Gain: " + std::to_string(channelGainsDSP_[i].getGainLinear()) + "\n";
-  }
-  LOG_ANALYTICS(0, channelGainDSPsInfo);
 }
 
 void GainProcessor::processBlock(juce::AudioBuffer<float>& buffer,

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -40,6 +40,7 @@ const juce::String GainProcessor::getName() const { return {"Gain"}; }
 //==============================================================================
 void GainProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
   updateAllAudioParameterFloats();
+  channelGainsDSP_ = InitializeChannelGainsDSPs();
   m_samplesPerBlock_ = samplesPerBlock;
   for (auto i = 0; i < channelGainsDSP_.size(); ++i) {
     channelGainsDSP_[i].prepare(
@@ -98,7 +99,6 @@ GainProcessor::InitializeChannelGainsDSPs() {
 
   for (auto i = 0; i < gains_.size(); ++i) {
     channelGainsDSPs[i].setGainLinear(gains_[i]->get());
-    ;
   }
   return channelGainsDSPs;
 }
@@ -135,6 +135,7 @@ void GainProcessor::valueTreePropertyChanged(juce::ValueTree& tree,
                                              const juce::Identifier& property) {
   juce::ignoreUnused(tree);
   updateAllAudioParameterFloats();
+  InitializeChannelGainsDSPs();
 }
 
 void GainProcessor::toggleChannelMute(const int& channel) {

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -15,6 +15,7 @@
 #include "GainProcessor.h"
 
 #include "GainEditor.h"
+#include "logger/logger.h"
 
 //==============================================================================
 GainProcessor::GainProcessor(MultiChannelRepository* gainRepository)
@@ -45,6 +46,17 @@ void GainProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
         {sampleRate, static_cast<uint32_t>(samplesPerBlock),
          static_cast<uint32_t>(channelGainsDSP_.size())});
   }
+  LOG_ANALYTICS(
+      0, "PrepareToPlay GainProcessor, gain repo: \n" +
+             channelGains_->get().toValueTree().toXmlString().toStdString());
+
+  std::string channelGainDSPsInfo = "Channel Gains DSPs:\n";
+  for (int i = 0; i < channelGainsDSP_.size(); i++) {
+    channelGainDSPsInfo +=
+        "Channel " + std::to_string(i) +
+        " Gain: " + std::to_string(channelGainsDSP_[i].getGainLinear()) + "\n";
+  }
+  LOG_ANALYTICS(0, channelGainDSPsInfo);
 }
 
 void GainProcessor::processBlock(juce::AudioBuffer<float>& buffer,

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -15,7 +15,6 @@
 #include "GainProcessor.h"
 
 #include "GainEditor.h"
-#include "logger/logger.h"
 
 //==============================================================================
 GainProcessor::GainProcessor(MultiChannelRepository* gainRepository)

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -39,8 +39,7 @@ const juce::String GainProcessor::getName() const { return {"Gain"}; }
 
 //==============================================================================
 void GainProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
-  updateAllAudioParameterFloats();
-  channelGainsDSP_ = InitializeChannelGainsDSPs();
+  updateGains();
   m_samplesPerBlock_ = samplesPerBlock;
   for (auto i = 0; i < channelGainsDSP_.size(); ++i) {
     channelGainsDSP_[i].prepare(
@@ -134,8 +133,7 @@ void GainProcessor::updateAllAudioParameterFloats() {
 void GainProcessor::valueTreePropertyChanged(juce::ValueTree& tree,
                                              const juce::Identifier& property) {
   juce::ignoreUnused(tree);
-  updateAllAudioParameterFloats();
-  InitializeChannelGainsDSPs();
+  updateGains();
 }
 
 void GainProcessor::toggleChannelMute(const int& channel) {

--- a/common/processors/gain/GainProcessor.cpp
+++ b/common/processors/gain/GainProcessor.cpp
@@ -70,7 +70,8 @@ void GainProcessor::setGain(const int& channel, const float& gainValue) {
 
 void GainProcessor::ResetGains() {
   // the new ChannelGains object will have a default gain of 1.f
-  channelGains_->update(ChannelGains(gainrepo_id_, "multichannel_Gains", 28));
+  channelGains_->update(ChannelGains(gainrepo_id_, "multichannel_Gains",
+                                     getHostWideLayout().size()));
 }
 
 //==============================================================================
@@ -110,37 +111,15 @@ GainProcessor::InitializeGainParameters() {
 }
 
 void GainProcessor::updateAllAudioParameterFloats() {
-  for (int i = 0; i < channelGains_->get().getGains().size(); i++) {
-    *gains_[i] = channelGains_->get().getGains()[i];
+  ChannelGains copy = channelGains_->get();
+  std::vector<float> gains = copy.getGains();
+  for (int i = 0; i < gains.size(); i++) {
+    *gains_[i] = gains[i];
   }
 }
 
 void GainProcessor::valueTreePropertyChanged(juce::ValueTree& tree,
                                              const juce::Identifier& property) {
-  juce::ignoreUnused(tree);
-  updateAllAudioParameterFloats();
-}
-
-void GainProcessor::valueTreeChildAdded(juce::ValueTree& parent,
-                                        juce::ValueTree& child) {
-  juce::ignoreUnused(parent);
-}
-
-void GainProcessor::valueTreeChildRemoved(juce::ValueTree& parent,
-                                          juce::ValueTree& child, int index) {
-  juce::ignoreUnused(parent);
-}
-
-void GainProcessor::valueTreeChildOrderChanged(juce::ValueTree& parent,
-                                               int oldIndex, int newIndex) {
-  juce::ignoreUnused(parent);
-}
-
-void GainProcessor::valueTreeParentChanged(juce::ValueTree& tree) {
-  juce::ignoreUnused(tree);
-}
-
-void GainProcessor::valueTreeRedirected(juce::ValueTree& tree) {
   juce::ignoreUnused(tree);
   updateAllAudioParameterFloats();
 }

--- a/common/processors/gain/GainProcessor.h
+++ b/common/processors/gain/GainProcessor.h
@@ -67,11 +67,18 @@ class GainProcessor final : public ProcessorBase,
     return gains_;
   }
 
+  void reinitializeAfterStateRestore() override { updateGains(); }
+
   void toggleChannelMute(const int& channel);
 
   void ResetGains();
 
   void updateAllAudioParameterFloats();
+
+  void updateGains() {
+    updateAllAudioParameterFloats();
+    channelGainsDSP_ = InitializeChannelGainsDSPs();
+  }
 
   std::unordered_map<int, float> getMutedChannelsfromRepo() {
     return channelGains_->get().getMutedChannels();

--- a/common/processors/gain/GainProcessor.h
+++ b/common/processors/gain/GainProcessor.h
@@ -58,15 +58,6 @@ class GainProcessor final : public ProcessorBase,
 
   virtual void valueTreePropertyChanged(
       juce::ValueTree& tree, const juce::Identifier& property) override;
-  virtual void valueTreeChildAdded(juce::ValueTree& parent,
-                                   juce::ValueTree& child) override;
-  virtual void valueTreeChildRemoved(juce::ValueTree& parent,
-                                     juce::ValueTree& child,
-                                     int index) override;
-  virtual void valueTreeChildOrderChanged(juce::ValueTree& parent, int oldIndex,
-                                          int newIndex) override;
-  virtual void valueTreeParentChanged(juce::ValueTree& tree) override;
-  virtual void valueTreeRedirected(juce::ValueTree& tree) override;
 
   int getGainRepoInputChannels() {
     return channelGains_->get().getTotalChannels();

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -325,6 +325,11 @@ void RendererProcessor::updateRepositories() {
       persistentState_.getChildWithName(kMultiChannelGainsKey);
   if (channelGains.isValid()) {
     multichannelgainRepository_.setStateTree(channelGains);
+    LOG_ANALYTICS(
+        instanceId_,
+        "setStateInformation: MultiChannelGainRepository was "
+        "successfully loaded from persistent state. \n" +
+            multichannelgainRepository_.getTree().toXmlString().toStdString());
   }
 
   juce::ValueTree muteSoloPlayback =
@@ -432,9 +437,9 @@ void RendererProcessor::initializeMixPresentations() {
 }
 
 void RendererProcessor::configureOutputBus() {
-  // Reaper/VST3 does not support changing the output channel set from Stereo to
-  // other layouts dynamically, so we need to reconfigure the output bus when
-  // the room setup changes.
+  // Reaper/VST3 does not support changing the output channel set from Stereo
+  // to other layouts dynamically, so we need to reconfigure the output bus
+  // when the room setup changes.
   auto hostType = juce::PluginHostType();
   if (!hostType.isReaper()) {
     LOG_ANALYTICS(instanceId_,
@@ -449,12 +454,14 @@ void RendererProcessor::configureOutputBus() {
     outputChannelSet_ =
         roomSetup.getSpeakerLayout().getRoomSpeakerLayout().getChannelSet();
     newChannelSetMsg =
-        "roomSetup.getSpeakerLayout() is valid. Setting outputChannelSet_ to " +
+        "roomSetup.getSpeakerLayout() is valid. Setting outputChannelSet_ "
+        "to " +
         outputChannelSet_.getDescription().toStdString() + "\n";
   } else {
     outputChannelSet_ = juce::AudioChannelSet::stereo();
     newChannelSetMsg =
-        "roomSetup.getSpeakerLayout() is NOT valid. Setting outputChannelSet_ "
+        "roomSetup.getSpeakerLayout() is NOT valid. Setting "
+        "outputChannelSet_ "
         "to stereo \n";
   }
 

--- a/rendererplugin/src/screens/mix_tabs/PresentationTab.cpp
+++ b/rendererplugin/src/screens/mix_tabs/PresentationTab.cpp
@@ -26,7 +26,6 @@ PresentationTab::PresentationTab(juce::Uuid mixPresID,
     : repos_(repos),
       audioElementRepository_(&repos.aeRepo_),
       kmixPresID_(mixPresID),
-      multichannelGainRepo_(&repos.chGainRepo_),
       activeMixRepository_(&repos.activeMPRepo_),
       channelMonitorData_(channelMonitorData),
       mixPresentationRepository_(&repos.mpRepo_),
@@ -87,10 +86,6 @@ void PresentationTab::paint(juce::Graphics& g) {
     newbounds.removeFromTop(stripSpacing);
     strip->getBounds();
   }
-}
-
-MultiChannelRepository* PresentationTab::getMultiChannelRepository() {
-  return multichannelGainRepo_;
 }
 
 std::vector<AudioElement> PresentationTab::getAudioElements() {

--- a/rendererplugin/src/screens/mix_tabs/PresentationTab.h
+++ b/rendererplugin/src/screens/mix_tabs/PresentationTab.h
@@ -35,8 +35,6 @@ class PresentationTab : public juce::Component,
 
   void paint(juce::Graphics& g) override;
 
-  MultiChannelRepository* getMultiChannelRepository();
-
   std::vector<AudioElement> getAudioElements();
 
   void updateActiveMixPresentation() {
@@ -120,7 +118,6 @@ class PresentationTab : public juce::Component,
       audioElements_;  // the audio elements that belong to this mix
   std::vector<MixPresentationAudioElement> mixpresentationAudioElements_;
 
-  MultiChannelRepository* multichannelGainRepo_;
   ChannelMonitorData& channelMonitorData_;
   juce::OwnedArray<AEStripComponent> aeStrips_;
 


### PR DESCRIPTION
### Description
Addressed the bug where the solo mute state of audio elements did not persist in the Gain Repository when the Renderer's UI was closed and re-opened.

### Changes
Ensured the listener callbacks that mute/unmute channels only execute when the audio element belongs to the active mix presentation

### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ] Built locally and ensured the solo/mute state persisted during playbacks after closing and re-opening the plugin
