### PR TITLE
Only Draw Track Loudness if Audio Element is not Muted

### DIFF
--- a/common/components/src/room_views/PerspectiveRoomView.cpp
+++ b/common/components/src/room_views/PerspectiveRoomView.cpp
@@ -23,7 +23,8 @@ PerspectiveRoomView::PerspectiveRoomView(
     const std::unordered_set<SpeakerLookup::SpeakerTag>& hiddenSpeakers,
     const juce::Image& figure, const SpeakerMonitorData& monitorData,
     RepositoryCollection repos)
-    : kFaces_(faces),
+    : kTransformMat_(transformMat),
+      kFaces_(faces),
       kHiddenSpeakers_(hiddenSpeakers),
       transformedFaces_(std::vector<DrawableFace>(faces.size())),
       monitorData_(monitorData),

--- a/common/components/src/room_views/PerspectiveRoomView.cpp
+++ b/common/components/src/room_views/PerspectiveRoomView.cpp
@@ -23,7 +23,7 @@ PerspectiveRoomView::PerspectiveRoomView(
     const std::unordered_set<SpeakerLookup::SpeakerTag>& hiddenSpeakers,
     const juce::Image& figure, const SpeakerMonitorData& monitorData,
     RepositoryCollection repos)
-      kFaces_(faces),
+    : kFaces_(faces),
       kHiddenSpeakers_(hiddenSpeakers),
       transformedFaces_(std::vector<DrawableFace>(faces.size())),
       monitorData_(monitorData),

--- a/common/components/src/room_views/PerspectiveRoomView.cpp
+++ b/common/components/src/room_views/PerspectiveRoomView.cpp
@@ -28,6 +28,8 @@ PerspectiveRoomView::PerspectiveRoomView(
       kHiddenSpeakers_(hiddenSpeakers),
       transformedFaces_(std::vector<DrawableFace>(faces.size())),
       monitorData_(monitorData),
+      rendererPlugin_(
+          true),  // Set to true if this is used in the renderer plugin.
       mixPresSMRepo_(&repos.mpSMRepo_),
       activeMixRepo_(&repos.activeMPRepo_),
       aeslRepo_(&repos.audioElementSpatialLayoutRepo_) {
@@ -45,7 +47,12 @@ PerspectiveRoomView::PerspectiveRoomView(
       kFaces_(faces),
       kHiddenSpeakers_(hiddenSpeakers),
       transformedFaces_(std::vector<DrawableFace>(faces.size())),
-      monitorData_(monitorData) {
+      monitorData_(monitorData),
+      rendererPlugin_(
+          false),  // Set to false if this is not used in the renderer plugin.
+      mixPresSMRepo_(nullptr),
+      activeMixRepo_(nullptr),
+      aeslRepo_(nullptr) {
   imageComponent_.setImage(figure);
   addAndMakeVisible(imageComponent_);
   setSpeakers(Speakers::kStereo);
@@ -138,8 +145,7 @@ void PerspectiveRoomView::transformDynamicVertices() {
   transformedTracks_.clear();
 
   MixPresentationSoloMute mixPresSoloMute;
-  if (mixPresSMRepo_ != nullptr && activeMixRepo_ != nullptr &&
-      aeslRepo_ != nullptr) {
+  if (rendererPlugin_) {
     juce::Uuid activeMix = activeMixRepo_->get().getActiveMixId();
     mixPresSoloMute = mixPresSMRepo_->get(activeMix).value();
   }
@@ -147,8 +153,7 @@ void PerspectiveRoomView::transformDynamicVertices() {
     DrawableTrack newTrack;
     Coordinates::Point4D pt = {data.x / 50, data.z / 50, -data.y / 50, 1.f};
     newTrack.pos = Coordinates::toWindow(kTransformMat_, wData, pt);
-    if (mixPresSMRepo_ != nullptr && activeMixRepo_ != nullptr &&
-        aeslRepo_ != nullptr) {
+    if (rendererPlugin_) {
       newTrack.trackLoudness = assignTrackLoudness(data, mixPresSoloMute);
     } else {
       newTrack.trackLoudness = data.loudness;

--- a/common/components/src/room_views/PerspectiveRoomView.h
+++ b/common/components/src/room_views/PerspectiveRoomView.h
@@ -33,6 +33,13 @@ class PerspectiveRoomView : public juce::Component {
       const std::vector<FaceLookup::Face>& faces,
       const Coordinates::Mat4& transformMat,
       const std::unordered_set<SpeakerLookup::SpeakerTag>& hiddenSpeakers,
+      const juce::Image& figure, const SpeakerMonitorData& monitorData,
+      RepositoryCollection repos);
+
+  PerspectiveRoomView(
+      const std::vector<FaceLookup::Face>& faces,
+      const Coordinates::Mat4& transformMat,
+      const std::unordered_set<SpeakerLookup::SpeakerTag>& hiddenSpeakers,
       const juce::Image& figure, const SpeakerMonitorData& monitorData);
   ~PerspectiveRoomView() = default;
 
@@ -97,10 +104,18 @@ class PerspectiveRoomView : public juce::Component {
   std::vector<DrawableTrack> transformedTracks_;
 
  private:
+  const float assignTrackLoudness(
+      const AudioElementUpdateData& data,
+      const MixPresentationSoloMute& mixPresSoloMute);
+
+  const juce::Uuid getTrackAudioElementUuid(const std::array<char, 16>& uuid);
   void updateSpeakerColours();
 
   // Data sources. //
   const SpeakerMonitorData& monitorData_;
+  MixPresentationSoloMuteRepository* mixPresSMRepo_;
+  ActiveMixRepository* activeMixRepo_;
+  MultibaseAudioElementSpatialLayoutRepository* aeslRepo_;
   // Data inherent to the room view. //
   const std::vector<FaceLookup::Face> kFaces_;
   // Speakers that are not be drawn for the current room view.

--- a/common/components/src/room_views/PerspectiveRoomView.h
+++ b/common/components/src/room_views/PerspectiveRoomView.h
@@ -113,6 +113,8 @@ class PerspectiveRoomView : public juce::Component {
 
   // Data sources. //
   const SpeakerMonitorData& monitorData_;
+  const bool rendererPlugin_;  // if true the perspective room view is used
+                               // in the renderer plugin.
   MixPresentationSoloMuteRepository* mixPresSMRepo_;
   ActiveMixRepository* activeMixRepo_;
   MultibaseAudioElementSpatialLayoutRepository* aeslRepo_;

--- a/common/components/src/room_views/PerspectiveRoomViews.cpp
+++ b/common/components/src/room_views/PerspectiveRoomViews.cpp
@@ -14,47 +14,53 @@
 
 #include "PerspectiveRoomViews.h"
 
-TopView::TopView(const SpeakerMonitorData& monitorData)
+#include "data_structures/src/RepositoryCollection.h"
+
+TopView::TopView(const SpeakerMonitorData& monitorData,
+                 RepositoryCollection repos)
     : PerspectiveRoomView(
           FaceLookup::getFaces(FaceLookup::kTop),
           Coordinates::getTopViewTransform(), {SpeakerLookup::kLFE},
-          IconStore::getInstance().getTopIcon(), monitorData) {};
+          IconStore::getInstance().getTopIcon(), monitorData, repos){};
 
 const float TopView::getTrackScaling(const Coordinates::Point4D pt) const {
   return 0.35 * pt.a[FaceLookup::kAxisY] + 1.35;
 };
 
-SideView::SideView(const SpeakerMonitorData& monitorData)
+SideView::SideView(const SpeakerMonitorData& monitorData,
+                   RepositoryCollection repos)
     : PerspectiveRoomView(
           FaceLookup::getFaces(FaceLookup::kSide),
           Coordinates::getSideViewTransform(),
           {SpeakerLookup::kLS, SpeakerLookup::kLSS, SpeakerLookup::kLRS,
            SpeakerLookup::kLTR, SpeakerLookup::kLFE, SpeakerLookup::kFL,
            SpeakerLookup::kSIL},
-          IconStore::getInstance().getLeftIcon(), monitorData) {};
+          IconStore::getInstance().getLeftIcon(), monitorData, repos){};
 
 const float SideView::getTrackScaling(const Coordinates::Point4D pt) const {
   return -0.35 * pt.a[FaceLookup::kAxisX] + 1.35;
 };
 
-RearView::RearView(const SpeakerMonitorData& monitorData)
+RearView::RearView(const SpeakerMonitorData& monitorData,
+                   RepositoryCollection repos)
     : PerspectiveRoomView(
           FaceLookup::getFaces(FaceLookup::kRear),
           Coordinates::getRearViewTransform(),
           {SpeakerLookup::kLTB, SpeakerLookup::kRTB, SpeakerLookup::kLFE,
            SpeakerLookup::kTPBL, SpeakerLookup::kTPBR, SpeakerLookup::kBL,
            SpeakerLookup::kBR},
-          IconStore::getInstance().getBackIcon(), monitorData) {};
+          IconStore::getInstance().getBackIcon(), monitorData, repos){};
 
 const float RearView::getTrackScaling(const Coordinates::Point4D pt) const {
   return 0.35 * pt.a[FaceLookup::kAxisZ] + 1.35;
 };
 
-IsoView::IsoView(const SpeakerMonitorData& monitorData)
+IsoView::IsoView(const SpeakerMonitorData& monitorData,
+                 RepositoryCollection repos)
     : PerspectiveRoomView(
           FaceLookup::getFaces(FaceLookup::kIso),
           Coordinates::getIsoViewTransform(), {SpeakerLookup::kLFE},
-          IconStore::getInstance().getIsoIcon(), monitorData) {};
+          IconStore::getInstance().getIsoIcon(), monitorData, repos){};
 
 void IsoView::drawFace(const std::array<Coordinates::Point2D, 4>& faceVerts,
                        const juce::Colour& c, juce::Graphics& g) {
@@ -94,7 +100,7 @@ AudioElementPluginRearView::AudioElementPluginRearView(
           {SpeakerLookup::kLTB, SpeakerLookup::kRTB, SpeakerLookup::kLFE,
            SpeakerLookup::kTPBL, SpeakerLookup::kTPBR, SpeakerLookup::kBL,
            SpeakerLookup::kBR},
-          {}, monitorData) {};
+          {}, monitorData){};
 
 const float AudioElementPluginRearView::getTrackScaling(
     const Coordinates::Point4D pt) const {

--- a/common/components/src/room_views/PerspectiveRoomViews.cpp
+++ b/common/components/src/room_views/PerspectiveRoomViews.cpp
@@ -21,7 +21,7 @@ TopView::TopView(const SpeakerMonitorData& monitorData,
     : PerspectiveRoomView(
           FaceLookup::getFaces(FaceLookup::kTop),
           Coordinates::getTopViewTransform(), {SpeakerLookup::kLFE},
-          IconStore::getInstance().getTopIcon(), monitorData, repos){};
+          IconStore::getInstance().getTopIcon(), monitorData, repos) {};
 
 const float TopView::getTrackScaling(const Coordinates::Point4D pt) const {
   return 0.35 * pt.a[FaceLookup::kAxisY] + 1.35;
@@ -35,7 +35,7 @@ SideView::SideView(const SpeakerMonitorData& monitorData,
           {SpeakerLookup::kLS, SpeakerLookup::kLSS, SpeakerLookup::kLRS,
            SpeakerLookup::kLTR, SpeakerLookup::kLFE, SpeakerLookup::kFL,
            SpeakerLookup::kSIL},
-          IconStore::getInstance().getLeftIcon(), monitorData, repos){};
+          IconStore::getInstance().getLeftIcon(), monitorData, repos) {};
 
 const float SideView::getTrackScaling(const Coordinates::Point4D pt) const {
   return -0.35 * pt.a[FaceLookup::kAxisX] + 1.35;
@@ -49,7 +49,7 @@ RearView::RearView(const SpeakerMonitorData& monitorData,
           {SpeakerLookup::kLTB, SpeakerLookup::kRTB, SpeakerLookup::kLFE,
            SpeakerLookup::kTPBL, SpeakerLookup::kTPBR, SpeakerLookup::kBL,
            SpeakerLookup::kBR},
-          IconStore::getInstance().getBackIcon(), monitorData, repos){};
+          IconStore::getInstance().getBackIcon(), monitorData, repos) {};
 
 const float RearView::getTrackScaling(const Coordinates::Point4D pt) const {
   return 0.35 * pt.a[FaceLookup::kAxisZ] + 1.35;
@@ -60,7 +60,7 @@ IsoView::IsoView(const SpeakerMonitorData& monitorData,
     : PerspectiveRoomView(
           FaceLookup::getFaces(FaceLookup::kIso),
           Coordinates::getIsoViewTransform(), {SpeakerLookup::kLFE},
-          IconStore::getInstance().getIsoIcon(), monitorData, repos){};
+          IconStore::getInstance().getIsoIcon(), monitorData, repos) {};
 
 void IsoView::drawFace(const std::array<Coordinates::Point2D, 4>& faceVerts,
                        const juce::Colour& c, juce::Graphics& g) {

--- a/common/components/src/room_views/PerspectiveRoomViews.cpp
+++ b/common/components/src/room_views/PerspectiveRoomViews.cpp
@@ -100,7 +100,7 @@ AudioElementPluginRearView::AudioElementPluginRearView(
           {SpeakerLookup::kLTB, SpeakerLookup::kRTB, SpeakerLookup::kLFE,
            SpeakerLookup::kTPBL, SpeakerLookup::kTPBR, SpeakerLookup::kBL,
            SpeakerLookup::kBR},
-          {}, monitorData){};
+          {}, monitorData) {};
 
 const float AudioElementPluginRearView::getTrackScaling(
     const Coordinates::Point4D pt) const {

--- a/common/components/src/room_views/PerspectiveRoomViews.h
+++ b/common/components/src/room_views/PerspectiveRoomViews.h
@@ -18,28 +18,29 @@
 #include "PerspectiveRoomView.h"
 #include "data_structures/src/AudioElementSpatialLayout.h"
 #include "data_structures/src/Elevation.h"
+#include "data_structures/src/RepositoryCollection.h"
 
 class TopView : public PerspectiveRoomView {
  public:
-  TopView(const SpeakerMonitorData& monitorData);
+  TopView(const SpeakerMonitorData& monitorData, RepositoryCollection repos);
   const float getTrackScaling(const Coordinates::Point4D pt) const override;
 };
 
 class SideView : public PerspectiveRoomView {
  public:
-  SideView(const SpeakerMonitorData& monitorData);
+  SideView(const SpeakerMonitorData& monitorData, RepositoryCollection repos);
   const float getTrackScaling(const Coordinates::Point4D pt) const override;
 };
 
 class RearView : public PerspectiveRoomView {
  public:
-  RearView(const SpeakerMonitorData& monitorData);
+  RearView(const SpeakerMonitorData& monitorData, RepositoryCollection repos);
   const float getTrackScaling(const Coordinates::Point4D pt) const override;
 };
 
 class IsoView : public PerspectiveRoomView {
  public:
-  IsoView(const SpeakerMonitorData& monitorData);
+  IsoView(const SpeakerMonitorData& monitorData, RepositoryCollection repos);
   void drawFace(const std::array<Coordinates::Point2D, 4>& faceVerts,
                 const juce::Colour& c, juce::Graphics& g) override;
   const float getTrackScaling(const Coordinates::Point4D pt) const override;

--- a/rendererplugin/src/screens/RoomMonitoringScreen.cpp
+++ b/rendererplugin/src/screens/RoomMonitoringScreen.cpp
@@ -47,7 +47,7 @@ RoomMonitoringScreen::RoomMonitoringScreen(RepositoryCollection repos,
   exportButton.setButtonText("Export");
   addAndMakeVisible(exportButton);
 
-  roomView_ = std::make_unique<IsoView>(monitorData_);
+  roomView_ = std::make_unique<IsoView>(monitorData_, repos_);
   addAndMakeVisible(roomView_.get());
 
   selRoomOpts_.onChange([this] { updateRoomOpts(); });
@@ -212,13 +212,13 @@ void RoomMonitoringScreen::updateRoomView() {
   LOG_ANALYTICS(RendererProcessor::instanceId_,
                 "room setup changed to: " + selView.toStdString());
   if (selView == "Iso") {
-    roomView_ = std::make_unique<IsoView>(monitorData_);
+    roomView_ = std::make_unique<IsoView>(monitorData_, repos_);
   } else if (selView == "Top") {
-    roomView_ = std::make_unique<TopView>(monitorData_);
+    roomView_ = std::make_unique<TopView>(monitorData_, repos_);
   } else if (selView == "Side") {
-    roomView_ = std::make_unique<SideView>(monitorData_);
+    roomView_ = std::make_unique<SideView>(monitorData_, repos_);
   } else {
-    roomView_ = std::make_unique<RearView>(monitorData_);
+    roomView_ = std::make_unique<RearView>(monitorData_, repos_);
   }
 
   addAndMakeVisible(roomView_.get());


### PR DESCRIPTION
### Description
Changed how the PerspectiveViewScreen draws track loudness. If the track is muted, the PerspectiveViewScreen will not draw the track's loudness.

### Changes
Passing the repository collection to the perspective view screen. 

### Validation and Acceptance Criteria
- [ ] Built and installed the Signed/Installer AAX, VST3 builds to ensure the GUI/UX was functional
