### PR TITLE
Setup the version information inside the plugin and initial version conversion functionality.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ cmake_minimum_required(VERSION 3.29.0)
 if(NOT DEFINED ECLIPSA_VERSION)
     set(ECLIPSA_VERSION "0.0.1" CACHE STRING "Version for Eclipsa project")
 endif()
+# Set the version information here so it can be used for determining
+# the configuration version
+add_compile_definitions(ECLIPSA_VERSION="${ECLIPSA_VERSION}")
 
 project(Eclipsa LANGUAGES C CXX VERSION ${ECLIPSA_VERSION})
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ To start, clone the repository and populate submodules.
 ```
 git clone --recurse-submodules <Repository URL>
 ```
-Currently the default plugin format that is built is 'Standalone' - a plugin format specific to JUCE which does not require external libraries nor a DAW to host it. This format is useful for quick builds, and is the format built by our CI.
+Currently the default plugin format that is built is 'Standalone' - a plugin format specific to JUCE which does not require external libraries nor a DAW to host it. This format is useful for quick builds, and is the format built by our CI. On MacOS, the Standalone version of the plugin is AU.
+
+Note that the following flags can be combined as needed.
 
 To build the plugin for an AAX (ProToolsDev) host, set flag ```BUILD_AAX```, and indicate preferred build system generator.
 
@@ -41,6 +43,11 @@ cmake -B ./build -DBUILD_VST3=ON -DCMAKE_BUILD_TYPE=Release -G Ninja
 To build all unit tests, set the flag ```INTERNAL_TEST```.
 ```
 cmake -B ./build -INTERNAL_TEST=ON -DCMAKE_BUILD_TYPE=Release -G Ninja
+```
+
+To set the version of the compiled Eclipsa plugin, set the flag ```ECLIPSA_VERSION```
+```
+cmake -B ./build -DECLIPSA_VERSION=0.0.1 -DCMAKE_BUILD_TYPE=Release -G Ninja
 ```
 
 Finally, after running the generate command above, the plugin can be build with the following command:
@@ -89,7 +96,7 @@ The project provides an installer for the AAX plugin which can be generated usin
 
 	Run the build command to generate release .aaxplugin files for both the Eclipsa Audio Renderer Plugin and Eclipsa Audio Element Plugin. 
 	```
-	cmake -B ./build -DBUILD_AAX=ON -DCMAKE_BUILD_TYPE=Release -G Ninja
+	cmake -B ./build -DBUILD_AAX=ON -DCMAKE_BUILD_TYPE=Release -DECLIPSA_VERSION=0.0.1 -G Ninja
 	cmake --build ./build
 	```
 	During the build, necessary libraries will be copied to each plugin’s Resources folder.

--- a/audioelementplugin/CMakeLists.txt
+++ b/audioelementplugin/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 juce_add_plugin(AudioElementPlugin
     PLUGIN_MANUFACTURER_CODE ${ECLIPSA_MANUFACTURER_CODE}
+    PLUGIN_CODE "Ecae"
     BUNDLE_ID "${ECLIPSA_PANNER_BUNDLE_ID}"
     COMPANY_NAME "${ECLIPSA_COMPANY_NAME}"
     NEEDS_MIDI_INPUT FALSE
@@ -29,6 +30,7 @@ target_sources(AudioElementPlugin
     PRIVATE
         src/AudioElementPluginProcessor.cpp
         src/AudioElementPluginEditor.cpp
+        src/AudioElementVersionConverter.cpp
         src/screens/RoomViewScreen.cpp
         src/screens/PositionSelectionScreen.cpp
         src/screens/TrackMonitorScreen.cpp)

--- a/audioelementplugin/src/AudioElementPluginProcessor.cpp
+++ b/audioelementplugin/src/AudioElementPluginProcessor.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "AudioElementPluginEditor.h"
+#include "AudioElementVersionConverter.h"
 #include "data_structures/src/AudioElementSpatialLayout.h"
 #include "data_structures/src/ParameterMetaData.h"
 #include "logger/logger.h"
@@ -219,6 +220,11 @@ void AudioElementPluginProcessor::getStateInformation(
 
   persistentState_.appendChild(automationTree, nullptr);
 
+  // Always add the latest version attribute to the XML state
+#if defined(ECLIPSA_VERSION)
+  persistentState_.setProperty("version", ECLIPSA_VERSION, nullptr);
+#endif
+
   copyXmlToBinary(*persistentState_.createXml(), destData);
   persistentState_.removeChild(automationTree, nullptr);
 }
@@ -233,6 +239,12 @@ void AudioElementPluginProcessor::setStateInformation(const void* data,
   if (xmlState.get() && xmlState->hasTagName(persistentState_.getType())) {
     persistentState_ = juce::ValueTree::fromXml(*xmlState);
   }
+
+  // Check the version converstion to see if version upgrade is needed and apply
+  // upgrades Do this before updating repositories since if we load the
+  // repositories and then update their values, it will cause tree change events
+  // on the processors, which normally updating the repositories would not do.
+  AudioElementVersionConverter::convertToLatestVersion(xmlState);
 
   juce::ValueTree audioElementSpatialLayoutTree =
       persistentState_.getChildWithName(

--- a/audioelementplugin/src/AudioElementPluginProcessor.cpp
+++ b/audioelementplugin/src/AudioElementPluginProcessor.cpp
@@ -222,6 +222,9 @@ void AudioElementPluginProcessor::getStateInformation(
 
   // Always add the latest version attribute to the XML state
 #if defined(ECLIPSA_VERSION)
+  LOG_ANALYTICS(instanceId_,
+                "Audio Element Plugin setting config version to \n" +
+                    std::string(ECLIPSA_VERSION));
   persistentState_.setProperty("version", ECLIPSA_VERSION, nullptr);
 #endif
 

--- a/audioelementplugin/src/AudioElementVersionConverter.cpp
+++ b/audioelementplugin/src/AudioElementVersionConverter.cpp
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "AudioElementVersionConverter.h"
+
+void AudioElementVersionConverter::convertToLatestVersion(
+    std::unique_ptr<juce::XmlElement>& xmlState) {
+  // Check for version attribute, if missing, convert from no version to 1.1.1
+  if (!xmlState->hasAttribute("version")) {
+    convertFrom_NoVersion_To_1p1p1(xmlState);
+  }
+
+  // Add further version conversion logic for future versions here as necessary
+  // Ensure version conversion logic is progressive (eg: check no version
+  // --> 1.1.1, then 1.1.1 --> 1.2.0, etc.) This way, any version can be
+  // converted to the latest version in a single pass.
+}
+
+void AudioElementVersionConverter::convertFrom_NoVersion_To_1p1p1(
+    std::unique_ptr<juce::XmlElement>& xmlState) {
+  xmlState->setAttribute("version", "1.1.1");
+}

--- a/audioelementplugin/src/AudioElementVersionConverter.h
+++ b/audioelementplugin/src/AudioElementVersionConverter.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <juce_data_structures/juce_data_structures.h>
+
+class AudioElementVersionConverter {
+ public:
+  // Converts the version of the plugin to the latest version.
+  // This function should be called during the plugin initialization.
+  static void convertToLatestVersion(
+      std::unique_ptr<juce::XmlElement>& xmlState);
+
+ private:
+  // Helper function to convert from an older version to a newer version.
+  static void convertFrom_NoVersion_To_1p1p1(
+      std::unique_ptr<juce::XmlElement>& xmlState);
+};

--- a/audioelementplugin/test/AudioElementVersionConverter_test.cpp
+++ b/audioelementplugin/test/AudioElementVersionConverter_test.cpp
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/AudioElementVersionConverter.h"
+
+#include <gtest/gtest.h>
+#include <juce_core/juce_core.h>
+
+TEST(AudioElementVersionConverterTest, AddsVersionAttributeWhenMissing) {
+  // Create an XmlElement without a version attribute
+  auto xml = std::make_unique<juce::XmlElement>("State");
+  ASSERT_FALSE(xml->hasAttribute("version"));
+
+  AudioElementVersionConverter::convertToLatestVersion(xml);
+  EXPECT_EQ(xml->getStringAttribute("version"), "1.1.1");
+}
+
+TEST(AudioElementVersionConverterTest, DoesNotOverwriteExistingVersion) {
+  auto xml = std::make_unique<juce::XmlElement>("State");
+  xml->setAttribute("version", "1.1.1");
+
+  AudioElementVersionConverter::convertToLatestVersion(xml);
+  EXPECT_EQ(xml->getStringAttribute("version"), "1.1.1");
+}

--- a/audioelementplugin/test/CMakeLists.txt
+++ b/audioelementplugin/test/CMakeLists.txt
@@ -11,4 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+eclipsa_add_test(test_audioelement_version_converter AudioElementVersionConverter_test.cpp "AudioElementPlugin;processors")
 

--- a/rendererplugin/CMakeLists.txt
+++ b/rendererplugin/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 juce_add_plugin(RendererPlugin
     PLUGIN_MANUFACTURER_CODE ${ECLIPSA_MANUFACTURER_CODE}
+    PLUGIN_CODE "Ecrd"
     BUNDLE_ID "${ECLIPSA_RENDERER_BUNDLE_ID}"
     COMPANY_NAME "${ECLIPSA_COMPANY_NAME}"
     NEEDS_MIDI_INPUT FALSE
@@ -29,6 +30,7 @@ target_sources(RendererPlugin
     PRIVATE
         src/RendererProcessor.cpp
         src/RendererEditor.cpp
+        src/RendererVersionConverter.cpp
         src/screens/ElementRoutingScreen.cpp
         src/screens/FileExportScreen.cpp
         src/screens/PresentationMonitorScreen.cpp

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -229,6 +229,8 @@ void RendererProcessor::getStateInformation(juce::MemoryBlock& destData) {
 
 // Always add the latest version attribute to the XML state
 #if defined(ECLIPSA_VERSION)
+  LOG_ANALYTICS(instanceId_, "Renderer Plugin setting config version to \n" +
+                                 std::string(ECLIPSA_VERSION));
   persistentState_.setProperty("version", ECLIPSA_VERSION, nullptr);
 #endif
 

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -17,6 +17,7 @@
 #include <processors/processors.h>
 
 #include "RendererEditor.h"
+#include "RendererVersionConverter.h"
 #include "data_repository/implementation/ActiveMixPresentationRepository.h"
 #include "data_structures/src/ActiveMixPresentation.h"
 #include "data_structures/src/MixPresentation.h"
@@ -225,6 +226,12 @@ juce::AudioProcessorEditor* RendererProcessor::createEditor() {
 //==============================================================================
 void RendererProcessor::getStateInformation(juce::MemoryBlock& destData) {
   LOG_ANALYTICS(instanceId_, "RendererProcessor getStateInformation \n");
+
+// Always add the latest version attribute to the XML state
+#if defined(ECLIPSA_VERSION)
+  persistentState_.setProperty("version", ECLIPSA_VERSION, nullptr);
+#endif
+
   copyXmlToBinary(*persistentState_.createXml(), destData);
 }
 
@@ -236,6 +243,12 @@ void RendererProcessor::setStateInformation(const void* data, int sizeInBytes) {
   if (xmlState.get() && xmlState->hasTagName(persistentState_.getType())) {
     persistentState_ = juce::ValueTree::fromXml(*xmlState);
   }
+
+  // Check the version converstion to see if version upgrade is needed and apply
+  // upgrades Do this before updating repositories since if we load the
+  // repositories and then update their values, it will cause tree change events
+  // on the processors, which normally updating the repositories would not do.
+  RendererVersionConverter::convertToLatestVersion(xmlState);
 
   updateRepositories();
 

--- a/rendererplugin/src/RendererVersionConverter.cpp
+++ b/rendererplugin/src/RendererVersionConverter.cpp
@@ -25,6 +25,10 @@ void RendererVersionConverter::convertToLatestVersion(
   // Ensure version conversion logic is progressive (eg: check no version
   // --> 1.1.1, then 1.1.1 --> 1.2.0, etc.) This way, any version can be
   // converted to the latest version in a single pass.
+
+  // Add a map for converting (eg: map 1.1.1 to 1.2.0, etc), associating the various
+  // map entries with a source and destintation version and a function to use for
+  // the conversion.
 }
 
 void RendererVersionConverter::convertFrom_NoVersion_To_1p1p1(

--- a/rendererplugin/src/RendererVersionConverter.cpp
+++ b/rendererplugin/src/RendererVersionConverter.cpp
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "RendererVersionConverter.h"
+
+void RendererVersionConverter::convertToLatestVersion(
+    std::unique_ptr<juce::XmlElement>& xmlState) {
+  // Check for version attribute, if missing, convert from no version to 1.1.1
+  if (!xmlState->hasAttribute("version")) {
+    convertFrom_NoVersion_To_1p1p1(xmlState);
+  }
+
+  // Add further version conversion logic for future versions here as necessary
+  // Ensure version conversion logic is progressive (eg: check no version
+  // --> 1.1.1, then 1.1.1 --> 1.2.0, etc.) This way, any version can be
+  // converted to the latest version in a single pass.
+}
+
+void RendererVersionConverter::convertFrom_NoVersion_To_1p1p1(
+    std::unique_ptr<juce::XmlElement>& xmlState) {
+  xmlState->setAttribute("version", "1.1.1");
+}

--- a/rendererplugin/src/RendererVersionConverter.cpp
+++ b/rendererplugin/src/RendererVersionConverter.cpp
@@ -26,9 +26,9 @@ void RendererVersionConverter::convertToLatestVersion(
   // --> 1.1.1, then 1.1.1 --> 1.2.0, etc.) This way, any version can be
   // converted to the latest version in a single pass.
 
-  // Add a map for converting (eg: map 1.1.1 to 1.2.0, etc), associating the various
-  // map entries with a source and destintation version and a function to use for
-  // the conversion.
+  // Add a map for converting (eg: map 1.1.1 to 1.2.0, etc), associating the
+  // various map entries with a source and destintation version and a function
+  // to use for the conversion.
 }
 
 void RendererVersionConverter::convertFrom_NoVersion_To_1p1p1(

--- a/rendererplugin/src/RendererVersionConverter.h
+++ b/rendererplugin/src/RendererVersionConverter.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <juce_data_structures/juce_data_structures.h>
+
+class RendererVersionConverter {
+ public:
+  // Converts the version of the plugin to the latest version.
+  // This function should be called during the plugin initialization.
+  static void convertToLatestVersion(
+      std::unique_ptr<juce::XmlElement>& xmlState);
+
+ private:
+  // Helper function to convert from an older version to a newer version.
+  static void convertFrom_NoVersion_To_1p1p1(
+      std::unique_ptr<juce::XmlElement>& xmlState);
+};

--- a/rendererplugin/test/CMakeLists.txt
+++ b/rendererplugin/test/CMakeLists.txt
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 eclipsa_add_test(test_renderer_processor RendererProcessor_test.cpp "RendererPlugin;processors")
+eclipsa_add_test(test_renderer_version_converter RendererVersionConverter_test.cpp "RendererPlugin;processors")

--- a/rendererplugin/test/RendererVersionConverter_test.cpp
+++ b/rendererplugin/test/RendererVersionConverter_test.cpp
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/RendererVersionConverter.h"
+
+#include <gtest/gtest.h>
+#include <juce_core/juce_core.h>
+
+TEST(RendererVersionConverterTest, AddsVersionAttributeWhenMissing) {
+  // Create an XmlElement without a version attribute
+  auto xml = std::make_unique<juce::XmlElement>("State");
+  ASSERT_FALSE(xml->hasAttribute("version"));
+
+  RendererVersionConverter::convertToLatestVersion(xml);
+  EXPECT_EQ(xml->getStringAttribute("version"), "1.1.1");
+}
+
+TEST(RendererVersionConverterTest, DoesNotOverwriteExistingVersion) {
+  auto xml = std::make_unique<juce::XmlElement>("State");
+  xml->setAttribute("version", "1.1.1");
+
+  RendererVersionConverter::convertToLatestVersion(xml);
+  EXPECT_EQ(xml->getStringAttribute("version"), "1.1.1");
+}


### PR DESCRIPTION
### Description
Setup version conversion to allow the plugin to be seamlessly updated.

Basically, there are two issues here. One is that DAW's need a way to recognize the plugin after update. We set te "PLUGIN_CODE" to a hardcoded value to use this + the manufacturer code to re-identify the plugin.

We then need handling for the case where the underlying plugin configuration structure may have changed. I've proposed a simple system in this PR where we pull the compiled version in and store it with the configuration, then use this information for performing configuration updates on load if needed. In the future, we can check for previous versions (eg: 1.1.2, 1.1.3, etc) and then convert them as necessary (eg: to 1.2.1 and so forth). Probably we will add a mapping at this time, but I've intentionally left this out so that we can reconsider when we actually need to do this.

### Changes
- Added a plugin code
- Added the version information to the compiled code
- Added the version information to the written configuration
- Added a placeholder version conversion function, which is a no-op for now, for future version conversion setup 

### Validation and Acceptance Criteria
- Unit tests for the version conversion function
- This is a bit of a weird one to test, but you can artificially advance the Eclipsa_Version using the cmake settings. Eg:
{
    "cmake.configureSettings": {
        "BUILD_AAX": "ON",
        "INTERNAL_TEST": "ON",
        "BUILD_VST3": "ON",
        "ECLIPSA_VERSION": "1.2.1",
    },

And then rebuild with different version numbers and observe that the various DAWs don't complain any more when the plugin is updated.
