### PR TITLE
Bug Fix: Channel Monitor Bug

### DIFF
--- a/common/components/src/AEStripComponent.cpp
+++ b/common/components/src/AEStripComponent.cpp
@@ -229,12 +229,7 @@ void AEStripComponent::timerCallback() {
   const bool ableToRead =
       channelMonitorData_.channelLoudnesses.read(channelLoudnessesRead_);
   for (auto channelIndex : channelsSet_) {
-    if (!ableToRead || channelLoudnessesRead_.size() < channelsSet_.size()) {
-      channelIndicators[i]->setColour(0);  // inactive
-    } else {
-      channelIndicators[i]->setColour(determineColourIndex(channelIndex));
-    }
-
+    channelIndicators[i]->setColour(determineColourIndex(channelIndex));
     channelIndicators[i]->repaint();
     ++i;
   }

--- a/common/components/src/AEStripComponent.cpp
+++ b/common/components/src/AEStripComponent.cpp
@@ -226,6 +226,7 @@ juce::Rectangle<int> AEStripComponent::setLightsSpacing(
 
 void AEStripComponent::timerCallback() {
   size_t i = 0;
+  channelMonitorData_.channelLoudnesses.read(channelLoudnessesRead_);
   for (auto channelIndex : channelsSet_) {
     channelIndicators[i]->setColour(determineColourIndex(channelIndex));
     channelIndicators[i]->repaint();

--- a/common/components/src/AEStripComponent.cpp
+++ b/common/components/src/AEStripComponent.cpp
@@ -226,9 +226,15 @@ juce::Rectangle<int> AEStripComponent::setLightsSpacing(
 
 void AEStripComponent::timerCallback() {
   size_t i = 0;
-  channelMonitorData_.channelLoudnesses.read(channelLoudnessesRead_);
+  const bool ableToRead =
+      channelMonitorData_.channelLoudnesses.read(channelLoudnessesRead_);
   for (auto channelIndex : channelsSet_) {
-    channelIndicators[i]->setColour(determineColourIndex(channelIndex));
+    if (!ableToRead || channelLoudnessesRead_.size() < channelsSet_.size()) {
+      channelIndicators[i]->setColour(0);  // inactive
+    } else {
+      channelIndicators[i]->setColour(determineColourIndex(channelIndex));
+    }
+
     channelIndicators[i]->repaint();
     ++i;
   }

--- a/common/components/src/AEStripComponent.cpp
+++ b/common/components/src/AEStripComponent.cpp
@@ -226,8 +226,6 @@ juce::Rectangle<int> AEStripComponent::setLightsSpacing(
 
 void AEStripComponent::timerCallback() {
   size_t i = 0;
-  const bool ableToRead =
-      channelMonitorData_.channelLoudnesses.read(channelLoudnessesRead_);
   for (auto channelIndex : channelsSet_) {
     channelIndicators[i]->setColour(determineColourIndex(channelIndex));
     channelIndicators[i]->repaint();

--- a/common/processors/channel_monitor/ChannelMonitorProcessor.cpp
+++ b/common/processors/channel_monitor/ChannelMonitorProcessor.cpp
@@ -28,6 +28,7 @@ ChannelMonitorProcessor::ChannelMonitorProcessor(
       loudness_(std::vector<float>(numChannels_, -300.f)),
       mixPresentationRepository_(mixPresentationRepository),
       mixPresentationSoloMuteRepository_(mixPresentationSoloMuteRepository) {
+  channelMonitorData_.reinitializeLoudnesses(numChannels_);
   mixPresentationRepository_->registerListener(this);
 }
 


### PR DESCRIPTION
### Description
Addressed a bug in PremierePro where the ChannelMonitorData is not updated prior to the TimeCallback of the AEStripComponent. This would results in a null reference in the determineColourIndex() function, as the channelLoudnessesRead_ vector would be empty or missing elements.

### Changes
Initializing the ChannelMonitorData in the constructor of the ChannelMonitorProcessor

### Validation and Acceptance Criteria
- [ ] Manually tested UI in PremierePro
- [ ] Created an AU installer and ensured the plugin UX was stable
