### PR TITLE
Bug Fix: Update loudness vec in chanel monitor processor

### DIFF
--- a/common/components/src/AEStripComponent.cpp
+++ b/common/components/src/AEStripComponent.cpp
@@ -229,12 +229,7 @@ void AEStripComponent::timerCallback() {
   const bool ableToRead =
       channelMonitorData_.channelLoudnesses.read(channelLoudnessesRead_);
   for (auto channelIndex : channelsSet_) {
-    if (!ableToRead || channelLoudnessesRead_.size() < channelsSet_.size()) {
-      channelIndicators[i]->setColour(0);  // inactive
-    } else {
-      channelIndicators[i]->setColour(determineColourIndex(channelIndex));
-    }
-
+    channelIndicators[i]->setColour(determineColourIndex(channelIndex));
     channelIndicators[i]->repaint();
     ++i;
   }

--- a/common/components/src/AEStripComponent.cpp
+++ b/common/components/src/AEStripComponent.cpp
@@ -226,9 +226,15 @@ juce::Rectangle<int> AEStripComponent::setLightsSpacing(
 
 void AEStripComponent::timerCallback() {
   size_t i = 0;
-  channelMonitorData_.channelLoudnesses.read(channelLoudnessesRead_);
+  const bool ableToRead =
+      channelMonitorData_.channelLoudnesses.read(channelLoudnessesRead_);
   for (auto channelIndex : channelsSet_) {
-    channelIndicators[i]->setColour(determineColourIndex(channelIndex));
+    if (!ableToRead || channelLoudnessesRead_.size() < channelsSet_.size()) {
+      channelIndicators[i]->setColour(0);  // inactive
+    } else {
+      channelIndicators[i]->setColour(determineColourIndex(channelIndex));
+    }
+
     channelIndicators[i]->repaint();
     ++i;
   }

--- a/common/data_structures/src/AudioElement.h
+++ b/common/data_structures/src/AudioElement.h
@@ -75,6 +75,8 @@ class AudioElement final : public RepositoryItemBase {
   inline static const juce::Identifier kDescription{"description"};
   inline static const juce::Identifier kChannelConfig{"channel_config"};
   inline static const juce::Identifier kFirstChannel{"first_channel"};
+  inline static const juce::Identifier kRepoTreeType{
+      "audio_elements"};  // for repository
 
  private:
   void populateScalableChannelLayoutConfig(

--- a/common/processors/channel_monitor/ChannelMonitorProcessor.cpp
+++ b/common/processors/channel_monitor/ChannelMonitorProcessor.cpp
@@ -14,25 +14,31 @@
 
 #include "ChannelMonitorProcessor.h"
 
+#include "data_repository/implementation/AudioElementRepository.h"
 #include "data_repository/implementation/MixPresentationRepository.h"
 #include "data_repository/implementation/MixPresentationSoloMuteRepository.h"
+#include "data_structures/src/AudioElement.h"
 #include "data_structures/src/ChannelMonitorData.h"
 #include "data_structures/src/MixPresentation.h"
 
 ChannelMonitorProcessor::ChannelMonitorProcessor(
     ChannelMonitorData& channelMonitorData,
     MixPresentationRepository* mixPresentationRepository,
-    MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository)
+    MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository,
+    AudioElementRepository* audioElementRepository)
     : numChannels_(juce::AudioChannelSet::ambisonic(5).size()),
       channelMonitorData_(channelMonitorData),
       loudness_(std::vector<float>(numChannels_, -300.f)),
       mixPresentationRepository_(mixPresentationRepository),
-      mixPresentationSoloMuteRepository_(mixPresentationSoloMuteRepository) {
+      mixPresentationSoloMuteRepository_(mixPresentationSoloMuteRepository),
+      audioElementRepository_(audioElementRepository) {
   mixPresentationRepository_->registerListener(this);
+  audioElementRepository_->registerListener(this);
 }
 
 ChannelMonitorProcessor::~ChannelMonitorProcessor() {
   mixPresentationRepository_->deregisterListener(this);
+  audioElementRepository_->deregisterListener(this);
 }
 
 const juce::String ChannelMonitorProcessor::getName() const {
@@ -95,6 +101,9 @@ void ChannelMonitorProcessor::valueTreeChildAdded(
     }
 
     mixPresentationSoloMuteRepository_->update(mixPresSoloMute);
+  } else if (parentTree.getType() == AudioElement::kRepoTreeType &&
+             childWhichHasBeenAdded.getType() == AudioElement::kTreeType) {
+    updateLoudnessVec();
   }
 }
 
@@ -127,5 +136,25 @@ void ChannelMonitorProcessor::valueTreeChildRemoved(
     }
 
     mixPresentationSoloMuteRepository_->update(mixPresSoloMute);
+  } else if (parentTree.getType() == AudioElement::kRepoTreeType &&
+             childWhichHasBeenRemoved.getType() == AudioElement::kTreeType) {
+    updateLoudnessVec();
   }
+}
+
+void ChannelMonitorProcessor::updateLoudnessVec() {
+  juce::OwnedArray<AudioElement> audioElements;
+  audioElementRepository_->getAll(audioElements);
+  int lastAEFirstChannel = 0;
+  int channelCount = 0;
+  for (const auto& audioElement : audioElements) {
+    int firstChannel = audioElement->getFirstChannel();
+    if (firstChannel >= lastAEFirstChannel) {
+      lastAEFirstChannel = firstChannel;
+      channelCount = audioElement->getChannelCount();
+    }
+  }
+  int numChannels = lastAEFirstChannel + channelCount;
+  loudness_.resize(numChannels, -300.f);
+  channelMonitorData_.channelLoudnesses.update(loudness_);
 }

--- a/common/processors/channel_monitor/ChannelMonitorProcessor.h
+++ b/common/processors/channel_monitor/ChannelMonitorProcessor.h
@@ -30,6 +30,7 @@
 
 #include "../../data_repository/implementation/MixPresentationRepository.h"
 #include "../processor_base/ProcessorBase.h"
+#include "data_repository/implementation/AudioElementRepository.h"
 #include "data_repository/implementation/MixPresentationSoloMuteRepository.h"
 
 //==============================================================================
@@ -39,7 +40,8 @@ class ChannelMonitorProcessor final : public ProcessorBase,
   ChannelMonitorProcessor(
       ChannelMonitorData& channelMonitorData,
       MixPresentationRepository* mixPresentationRepository,
-      MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository);
+      MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository,
+      AudioElementRepository* audioElementRepository);
   ~ChannelMonitorProcessor() override;
 
   void prepareToPlay(double sampleRate, int samplesPerBlock) override;
@@ -51,6 +53,8 @@ class ChannelMonitorProcessor final : public ProcessorBase,
   const juce::String getName() const override;
 
  private:
+  void updateLoudnessVec();
+
   void valueTreeChildAdded(juce::ValueTree& parentTree,
                            juce::ValueTree& childWhichHasBeenAdded) override;
 
@@ -61,6 +65,7 @@ class ChannelMonitorProcessor final : public ProcessorBase,
   ChannelMonitorData& channelMonitorData_;
   MixPresentationRepository* mixPresentationRepository_;
   MixPresentationSoloMuteRepository* mixPresentationSoloMuteRepository_;
+  AudioElementRepository* audioElementRepository_;
   int numChannels_;
   // replace with thread safe data-struct
   std::vector<float> loudness_;

--- a/common/processors/tests/ChannelMonitorProcessor_test.cpp
+++ b/common/processors/tests/ChannelMonitorProcessor_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "data_repository/implementation/AudioElementRepository.h"
 #include "data_structures/src/ChannelMonitorData.h"
 #include "data_structures/src/LanguageCodeMetaData.h"
 #include "data_structures/src/MixPresentation.h"
@@ -30,6 +31,9 @@ TEST(test_channelmonitor_processor, test_getPrerdrLoudness) {
   MixPresentationSoloMuteRepository mixPresentationSoloMuteRepository_ =
       juce::ValueTree("mixPresentationSoloMute");
 
+  AudioElementRepository audioElementRepository_ =
+      juce::ValueTree("audioElementRepository");
+
   // temporary hard-code for testing purposes
   juce::Uuid presentationUuid = juce::Uuid();
   MixPresentation presentation(presentationUuid, "English Mix", 1,
@@ -37,7 +41,7 @@ TEST(test_channelmonitor_processor, test_getPrerdrLoudness) {
 
   ChannelMonitorProcessor channelMonitorProcessor(
       channelMonitorData, &mixPresentationRepository_,
-      &mixPresentationSoloMuteRepository_);
+      &mixPresentationSoloMuteRepository_, &audioElementRepository_);
 
   // Check if the gains are being applied correctly
   // Create an AudioBuffer to test the processBlock function

--- a/rendererplugin/src/RendererProcessor.cpp
+++ b/rendererplugin/src/RendererProcessor.cpp
@@ -72,7 +72,7 @@ RendererProcessor::RendererProcessor()
   }
   audioProcessors_.push_back(std::make_unique<ChannelMonitorProcessor>(
       channelMonitorData_, &mixPresentationRepository_,
-      &mixPresentationSoloMuteRepository_));
+      &mixPresentationSoloMuteRepository_, &audioElementRepository_));
   audioProcessors_.push_back(std::make_unique<RenderProcessor>(
       this, &roomSetupRepository_, &audioElementRepository_,
       &mixPresentationRepository_, &activeMixPresentationRepository_,


### PR DESCRIPTION
### Description
Addressed a bug in PremierePro where the ChannelMonitorData is not updated prior to the TimerCallback of the AEStripComponent. This would results in a null reference in the determineColourIndex() function, as the channelLoudnessesRead_ vector would be empty or missing elements.

### Changes
Added a listener callback that ensures the loudness vector is the same size as the number of channels used by the audio elements.

### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ] Steps you have taken to validate your changes.
- [ ] Steps necessary for others to validate your PR if different.
