### PR TITLE
Fix Logic Pro compatibility issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ if(NOT DEFINED ECLIPSA_PANNER_BUNDLE_ID)
     set(ECLIPSA_PANNER_BUNDLE_ID "com.eclipsaproject.panner" CACHE STRING "Bundle ID for the panner plugin")
 endif()
 
+# Build configuration for different DAW targets
+option(ECLIPSA_LOGIC_PRO_BUILD "Build AU plugin optimized for Logic Pro (7.1.4 layout)" OFF)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/audioelementplugin/CMakeLists.txt
+++ b/audioelementplugin/CMakeLists.txt
@@ -44,6 +44,11 @@ target_compile_definitions(AudioElementPlugin
         JUCE_ENABLE_LIVE_CONSTANT_EDITOR=1
         JucePlugin_Category="Spatial")
 
+# Add DAW-specific build flags when enabled
+if(ECLIPSA_LOGIC_PRO_BUILD)
+    target_compile_definitions(AudioElementPlugin PRIVATE ECLIPSA_LOGIC_PRO_BUILD=1)
+endif()
+
 target_link_options(AudioElementPlugin
     PUBLIC
         "-Wl"

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -34,6 +34,11 @@ endif()
 
 target_compile_definitions(processors INTERFACE MUXER_PATH="${CMAKE_SOURCE_DIR}/external/FFmpeg/bin/ffmpeg")
 
+# Add DAW-specific build flags to processors module when enabled
+if(ECLIPSA_LOGIC_PRO_BUILD)
+    target_compile_definitions(processors INTERFACE ECLIPSA_LOGIC_PRO_BUILD=1)
+endif()
+
 add_subdirectory(components/icons)
 target_link_libraries(components INTERFACE binary_data)
 

--- a/common/processors/processor_base/ProcessorBase.h
+++ b/common/processors/processor_base/ProcessorBase.h
@@ -18,6 +18,16 @@
 
 #include <juce_audio_utils/juce_audio_utils.h>
 
+// Build configuration for Logic Pro compatibility
+// When true, limits to 7.1.4 layout for Logic Pro compatibility
+// When false, uses Ambisonics layouts (order 3 for Premiere, order 5 for
+// others)
+#ifdef ECLIPSA_LOGIC_PRO_BUILD
+constexpr bool kIsLogicProBuild = true;
+#else
+constexpr bool kIsLogicProBuild = false;
+#endif
+
 class ProcessorBase : public juce::AudioProcessor {
  public:
   // This constructor is called by our internal processors
@@ -46,14 +56,14 @@ class ProcessorBase : public juce::AudioProcessor {
   // Static helper so it can be used inside member initializer lists of
   // derived processors (cannot rely on virtual functions there).
   static inline juce::AudioChannelSet getHostWideLayout() {
-    // Non-AU builds: original behavior for all DAWs
-    if (juce::PluginHostType().isPremiere()) {
-      return juce::AudioChannelSet::ambisonic(3);
-    } else if (juce::PluginHostType().isLogic() ||
-               juce::PluginHostType().isAUVal()) {
+    if (kIsLogicProBuild) {
       return juce::AudioChannelSet::create7point1point4();
     } else {
-      return juce::AudioChannelSet::ambisonic(5);
+      if (juce::PluginHostType().isPremiere()) {
+        return juce::AudioChannelSet::ambisonic(3);
+      } else {
+        return juce::AudioChannelSet::ambisonic(5);
+      }
     }
   }
 

--- a/common/substream_rdr/tests/AudioPanner_test.cpp
+++ b/common/substream_rdr/tests/AudioPanner_test.cpp
@@ -40,7 +40,9 @@ struct TestLayout {
 };
 
 const std::vector<AudioElementSpeakerLayout> kAmbiOutputLayouts = {
-    Speakers::kHOA1, Speakers::kHOA2, Speakers::kHOA3,
+    Speakers::kHOA1,
+    Speakers::kHOA2,
+    Speakers::kHOA3,
     //  Speakers::kHOA4,Speakers::kHOA5, Speakers::kHOA6, Speakers::kHOA7
 };
 

--- a/rendererplugin/CMakeLists.txt
+++ b/rendererplugin/CMakeLists.txt
@@ -52,6 +52,11 @@ target_compile_definitions(RendererPlugin
         JucePlugin_IsSynth=1
         JucePlugin_Category="Synth")
 
+# Add DAW-specific build flags when enabled
+if(ECLIPSA_LOGIC_PRO_BUILD)
+    target_compile_definitions(RendererPlugin PRIVATE ECLIPSA_LOGIC_PRO_BUILD=1)
+endif()
+
 target_link_options(RendererPlugin
     PUBLIC
         "-Wl"


### PR DESCRIPTION
- Update AudioElementPluginProcessor for Logic Pro optimization
- Modify ProcessorBase.h for better Logic Pro integration
- Update CMakeLists.txt files with Logic Pro build configurations
- Fix renderer processor Logic Pro compatibility
- Update test cases for Logic Pro scenarios

Description
This PR introduces a new CMake build option ECLIPSA_LOGIC_PRO_OPTIMIZE to replace runtime JUCE host detection with compile-time macro definitions for Logic Pro specific optimizations. The existing JUCE conditions (juce::PluginHostType().isLogic() and juce::PluginHostType().isAUVal()) were not being recognized consistently on different systems, causing compatibility issues. This change provides a more reliable build-time approach to enable Logic Pro specific audio layout optimizations.

Changes
Added new CMake option: ECLIPSA_LOGIC_PRO_OPTIMIZE that defaults to OFF but can be enabled for Logic Pro optimized builds
Replaced runtime JUCE host detection: Removed juce::PluginHostType().isLogic() and juce::PluginHostType().isAUVal() checks with compile-time #ifdef ECLIPSA_LOGIC_PRO_OPTIMIZE preprocessor directives

Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.

 Build AU audio units and run auval testing
 open plugins in logic pro
