### PR TITLE
disable audioelement based on hostwide layout

### DIFF
--- a/audioelementplugin/CMakeLists.txt
+++ b/audioelementplugin/CMakeLists.txt
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Set plugin code and name based on build type
+if(ECLIPSA_LOGIC_PRO_BUILD)
+    set(AUDIO_ELEMENT_PLUGIN_CODE "Eacl")
+    set(AUDIO_ELEMENT_PRODUCT_NAME "Eclipsa Audio Element Plugin for Logic Pro")
+else()
+    set(AUDIO_ELEMENT_PLUGIN_CODE "Ecae")
+    set(AUDIO_ELEMENT_PRODUCT_NAME "Eclipsa Audio Element Plugin")
+endif()
+
 juce_add_plugin(AudioElementPlugin
     PLUGIN_MANUFACTURER_CODE ${ECLIPSA_MANUFACTURER_CODE}
-    PLUGIN_CODE "Eacl"
+    PLUGIN_CODE ${AUDIO_ELEMENT_PLUGIN_CODE}
     BUNDLE_ID "${ECLIPSA_PANNER_BUNDLE_ID}"
     COMPANY_NAME "${ECLIPSA_COMPANY_NAME}"
     NEEDS_MIDI_INPUT FALSE
@@ -23,7 +32,7 @@ juce_add_plugin(AudioElementPlugin
     EDITOR_WANTS_KEYBOARD_FOCUS FALSE
     COPY_PLUGIN_AFTER_BUILD TRUE
     FORMATS ${PLUGIN_FORMATS}
-    PRODUCT_NAME "Eclipsa Audio Element Plugin"
+    PRODUCT_NAME ${AUDIO_ELEMENT_PRODUCT_NAME}
     AAX_CATEGORY "AAX_ePlugInCategory_SoundField")
 
 target_sources(AudioElementPlugin 

--- a/common/components/src/SelectionButton.h
+++ b/common/components/src/SelectionButton.h
@@ -131,4 +131,12 @@ class SelectionButton : public juce::Component, juce::ComboBox::Listener {
   void addItemList(const juce::StringArray& items, int startIndex) {
     selectionBox_.addItemList(items, startIndex);
   }
+
+  void setItemEnabled(int itemId, bool shouldBeEnabled) {
+    selectionBox_.setItemEnabled(itemId, shouldBeEnabled);
+  }
+
+  bool isItemEnabled(int itemId) const {
+    return selectionBox_.isItemEnabled(itemId);
+  }
 };

--- a/rendererplugin/CMakeLists.txt
+++ b/rendererplugin/CMakeLists.txt
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Set plugin code and name based on build type
+if(ECLIPSA_LOGIC_PRO_BUILD)
+    set(RENDERER_PLUGIN_CODE "Ercl")
+    set(RENDERER_PRODUCT_NAME "Eclipsa Audio Renderer for Logic Pro")
+else()
+    set(RENDERER_PLUGIN_CODE "Ecrd")
+    set(RENDERER_PRODUCT_NAME "Eclipsa Audio Renderer")
+endif()
+
 juce_add_plugin(RendererPlugin
     PLUGIN_MANUFACTURER_CODE ${ECLIPSA_MANUFACTURER_CODE}
-    PLUGIN_CODE "Ercl"
+    PLUGIN_CODE ${RENDERER_PLUGIN_CODE}
     BUNDLE_ID "${ECLIPSA_RENDERER_BUNDLE_ID}"
     COMPANY_NAME "${ECLIPSA_COMPANY_NAME}"
     NEEDS_MIDI_INPUT FALSE
@@ -23,7 +32,7 @@ juce_add_plugin(RendererPlugin
     EDITOR_WANTS_KEYBOARD_FOCUS FALSE
     COPY_PLUGIN_AFTER_BUILD TRUE
     FORMATS ${PLUGIN_FORMATS}
-    PRODUCT_NAME "Eclipsa Audio Renderer"
+    PRODUCT_NAME ${RENDERER_PRODUCT_NAME}
     AAX_CATEGORY "AAX_ePlugInCategory_SWGenerators")
 
 target_sources(RendererPlugin 


### PR DESCRIPTION
### Description
Implements dynamic audio element layout constraints in the routing screen based on host-wide channel layout capabilities. Audio elements that exceed the host's channel capacity are now visible but disabled in the dropdown
### Changes
Provide a summary of changes and their scope.

- Audio Element: Eacl with "for Logic Pro" suffix vs Ecae with standard name

- Renderer: Ercl with "for Logic Pro" suffix vs Ecrd with standard name

### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ] Audio elements show all profile-appropriate layouts in dropdown
- [ ] Layouts exceeding host channel limits are disabled (grayed out) but visible
- [ ] Existing profile and channel constraint logic preserved
- [ ] Logic Pro builds generate distinct plugin codes and names
