### PR TITLE
Cleanup Data Queue Processing in MessagingThread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(CMAKE_BUILD_RPATH "@loader_path/../Resources;${CMAKE_SOURCE_DIR}")
 set(PLUGIN_FORMATS "AU")
 option(INTERNAL_TEST OFF)
 option(CI_TEST OFF)
+
 if(APPLE)
   # Add vendored libraries path (for CI/GitHub Actions)
   set(VENDOR_LIB_PATH "${CMAKE_SOURCE_DIR}/third_party/libiamf/third_party/lib/macos")

--- a/common/processors/audioelementplugin_publisher/MessagingThread.h
+++ b/common/processors/audioelementplugin_publisher/MessagingThread.h
@@ -29,7 +29,7 @@ class MessagingThread : public juce::Thread {
 
  private:
   void run() override;
-  juce::CriticalSection queueLock_;
+  juce::SpinLock queueLock_;
   std::vector<AudioElementUpdateData> dataQueue_;
   std::unique_ptr<AudioElementPublisher> publisher_;
 };


### PR DESCRIPTION
### Description
Unguarded data queue accesses were causing bad memory accesses around `dataQueue_` reads/writes. 

### Changes
- Protect writes with a lock. 
- Use a spinlock as the write method is called from the main audio process thread.   

### Validation and Acceptance Criteria
- [x] Validated in the DAW for a prolonged run time that changing panner params can no longer cause a crash.
