### PR TITLE
fix audio element plugin selection box delay

### DIFF
--- a/common/data_structures/src/AudioElementPluginSyncClient.h
+++ b/common/data_structures/src/AudioElementPluginSyncClient.h
@@ -105,7 +105,7 @@ class AudioElementPluginSyncClient : public juce::InterprocessConnection {
           return;
         }
         rendererAudioElementsLock_.exit();
-        std::this_thread::sleep_for(std::chrono::seconds(10));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       };
     });
   }


### PR DESCRIPTION
### Description
Fix the audio element plugin selection box delay to update audio element selection while opening saved project

### Changes
- Shortened delay in sync client `tryConnect()`

### Validation and Acceptance Criteria
- [x] Build AU plugins and verify changes in logic pro
