### PR TITLE
Fix audio element plugin delay

### DIFF
--- a/common/data_structures/src/AudioElementPluginSyncClient.h
+++ b/common/data_structures/src/AudioElementPluginSyncClient.h
@@ -105,7 +105,7 @@ class AudioElementPluginSyncClient : public juce::InterprocessConnection {
           return;
         }
         rendererAudioElementsLock_.exit();
-        std::this_thread::sleep_for(std::chrono::seconds(10));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       };
     });
   }

--- a/common/processors/panner/Panner3DProcessor.cpp
+++ b/common/processors/panner/Panner3DProcessor.cpp
@@ -14,6 +14,7 @@
 
 #include "Panner3DProcessor.h"
 
+#include <algorithm>
 #include <memory>
 
 #include "data_structures/src/AudioElementSpatialLayout.h"
@@ -52,7 +53,8 @@ Panner3DProcessor::~Panner3DProcessor() {
 }
 
 void Panner3DProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
-  samplesPerBlock_ = samplesPerBlock;
+  // Use 32 samples - the maximum that avoids artifacts in underlying renderers
+  samplesPerBlock_ = std::min(samplesPerBlock, 32);
   sampleRate_ = sampleRate;
   initializePanning();
 }
@@ -102,32 +104,68 @@ void Panner3DProcessor::initializePanning() {
 
 void Panner3DProcessor::processBlock(juce::AudioBuffer<float>& buffer,
                                      juce::MidiBuffer&) {
-  // On each frame, lock and set the position of the panner, since it may have
-  // changed
+  const int hostBufferSize = buffer.getNumSamples();
+  const int rendererChunkSize =
+      samplesPerBlock_;  // Always 32 samples to avoid artifacts
+
   renderLock.enter();
 
-  // Check to see if this is set up for passthrough
-  // We still need to lock to check since the panner could get
-  // updated during playback
   if (surroundPanner_ != NULL) {
     surroundPanner_->setPosition(xPosition_, yPosition_, zPosition_);
 
-    // Perform the panning operation
-    surroundPanner_->process(buffer, outputBuffer_);
+    // Process in chunks only if absolutely necessary
+    if (hostBufferSize <= rendererChunkSize) {
+      // Simple case: host buffer fits in one chunk - most efficient
+      surroundPanner_->process(buffer, outputBuffer_);
 
-    // Manually copy the number of channels of the output layout from the
-    // output buffer to the input buffer to avoid resizing.
-    const int copyChannels =
-        std::min(outputBuffer_.getNumChannels(), buffer.getNumChannels());
-    for (int channel = 0; channel < copyChannels; ++channel) {
-      buffer.copyFrom(channel, 0, outputBuffer_, channel, 0,
-                      buffer.getNumSamples());
-    }
-    // If truncated, clear any remaining host channels (so stale data isn't
-    // left)
-    for (int channel = copyChannels; channel < buffer.getNumChannels();
-         ++channel) {
-      buffer.clear(channel, 0, buffer.getNumSamples());
+      const int copyChannels =
+          std::min(outputBuffer_.getNumChannels(), buffer.getNumChannels());
+      for (int channel = 0; channel < copyChannels; ++channel) {
+        buffer.copyFrom(channel, 0, outputBuffer_, channel, 0, hostBufferSize);
+      }
+      for (int channel = copyChannels; channel < buffer.getNumChannels();
+           ++channel) {
+        buffer.clear(channel, 0, hostBufferSize);
+      }
+    } else {
+      // Optimized chunked processing - reuse buffers and minimize operations
+      static thread_local juce::AudioBuffer<float> chunkInput;
+      if (chunkInput.getNumChannels() != buffer.getNumChannels() ||
+          chunkInput.getNumSamples() != rendererChunkSize) {
+        chunkInput.setSize(buffer.getNumChannels(), rendererChunkSize, false,
+                           false, true);
+      }
+
+      for (int processed = 0; processed < hostBufferSize;
+           processed += rendererChunkSize) {
+        const int chunkSize =
+            std::min(rendererChunkSize, hostBufferSize - processed);
+
+        // Copy and clear in one pass
+        for (int channel = 0; channel < buffer.getNumChannels(); ++channel) {
+          chunkInput.copyFrom(channel, 0, buffer, channel, processed,
+                              chunkSize);
+          if (chunkSize < rendererChunkSize) {
+            chunkInput.clear(channel, chunkSize, rendererChunkSize - chunkSize);
+          }
+        }
+
+        // Process chunk
+        surroundPanner_->process(chunkInput, outputBuffer_);
+
+        // Copy back efficiently
+        const int copyChannels =
+            std::min(outputBuffer_.getNumChannels(), buffer.getNumChannels());
+        for (int channel = 0; channel < copyChannels; ++channel) {
+          buffer.copyFrom(channel, processed, outputBuffer_, channel, 0,
+                          chunkSize);
+        }
+        // Clear any extra channels
+        for (int channel = copyChannels; channel < buffer.getNumChannels();
+             ++channel) {
+          buffer.clear(channel, processed, chunkSize);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Description
Firstly, I tried smoothing where I changed parameter values across samples using a short envelope (e.g., via juce::SmoothedValue) so the renderer sees smooth transitions rather than abrupt jumps(they rate-limit or delay parameter changes), which is unacceptable for accurate automation playback and interpolation techniques where I Computed intermediate parameter values between automation samples using linear, cubic, or spline interpolation so each audio sample is processed with its correct interpolated parameter
Fixed audio artifacts observed during automation playback in Logic Pro (AU) by constraining the spatial renderer's internal buffer size and applying host-buffer chunking when necessary. The plugin previously exhibited intermittent distortion during parameter automation even when other DAWs (AAX in Pro Tools, VST3 in Reaper) were unaffected. We investigated multiple approaches (smoothing, interpolation, crossfading) and found the root cause: the spatial audio renderers produce audible artifacts with host buffers larger than 32 samples under automation workloads. The implemented solution caps the renderer block size to 32 samples and, when the host supplies larger buffers, splits the host buffer into 32-sample chunks, processes each chunk through the renderer, and reassembles the output. Thread-local static buffers are used to avoid per-block allocations.
### Changes
Limit renderer block size to 32 samples in panner initialization.
Use static thread_local juce::AudioBuffer<float> for chunk input/output buffers to minimize allocations and improve cache locality.
### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ] Build aax & au logic pro and test plugins with automaiton 
