### PR TITLE
fix automation for au logic pro

### DIFF
--- a/common/processors/panner/Panner3DProcessor.cpp
+++ b/common/processors/panner/Panner3DProcessor.cpp
@@ -53,8 +53,14 @@ Panner3DProcessor::~Panner3DProcessor() {
 }
 
 void Panner3DProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
-  // Use 32 samples - the maximum that avoids artifacts in underlying renderers
-  samplesPerBlock_ = std::min(samplesPerBlock, 32);
+  if (kIsAUBuild) {
+    // AU Build: Use 32-sample chunks to handle variable buffer sizes
+    samplesPerBlock_ = std::min(samplesPerBlock, 32);
+  } else {
+    // Non-AU builds (VST3, AAX, etc.): Use host buffer size directly
+    samplesPerBlock_ = samplesPerBlock;
+  }
+
   sampleRate_ = sampleRate;
   initializePanning();
 }
@@ -105,17 +111,84 @@ void Panner3DProcessor::initializePanning() {
 void Panner3DProcessor::processBlock(juce::AudioBuffer<float>& buffer,
                                      juce::MidiBuffer&) {
   const int hostBufferSize = buffer.getNumSamples();
-  const int rendererChunkSize =
-      samplesPerBlock_;  // Always 32 samples to avoid artifacts
 
   renderLock.enter();
 
   if (surroundPanner_ != NULL) {
-    surroundPanner_->setPosition(xPosition_, yPosition_, zPosition_);
+    // Only update position if it has changed - avoid redundant renderer updates
+    // This significantly reduces CPU load during automation with many callbacks
+    if (xPosition_ != lastSetXPosition_ || yPosition_ != lastSetYPosition_ ||
+        zPosition_ != lastSetZPosition_) {
+      surroundPanner_->setPosition(xPosition_, yPosition_, zPosition_);
+      lastSetXPosition_ = xPosition_;
+      lastSetYPosition_ = yPosition_;
+      lastSetZPosition_ = zPosition_;
+    }
 
-    // Process in chunks only if absolutely necessary
-    if (hostBufferSize <= rendererChunkSize) {
-      // Simple case: host buffer fits in one chunk - most efficient
+    if (kIsAUBuild) {
+      // AU Build: Chunked processing to handle Logic Pro's variable buffer
+      // sizes This prevents artifacts caused by buffer size changes during
+      // playback
+      const int rendererChunkSize = samplesPerBlock_;  // 32 samples for AU
+
+      if (hostBufferSize <= rendererChunkSize) {
+        // Simple case: host buffer fits in one chunk - most efficient
+        surroundPanner_->process(buffer, outputBuffer_);
+
+        const int copyChannels =
+            std::min(outputBuffer_.getNumChannels(), buffer.getNumChannels());
+        for (int channel = 0; channel < copyChannels; ++channel) {
+          buffer.copyFrom(channel, 0, outputBuffer_, channel, 0,
+                          hostBufferSize);
+        }
+        for (int channel = copyChannels; channel < buffer.getNumChannels();
+             ++channel) {
+          buffer.clear(channel, 0, hostBufferSize);
+        }
+      } else {
+        // Chunked processing: split large buffers into 32-sample chunks
+        static thread_local juce::AudioBuffer<float> chunkInput;
+        if (chunkInput.getNumChannels() != buffer.getNumChannels() ||
+            chunkInput.getNumSamples() != rendererChunkSize) {
+          chunkInput.setSize(buffer.getNumChannels(), rendererChunkSize, false,
+                             false, true);
+        }
+
+        for (int processed = 0; processed < hostBufferSize;
+             processed += rendererChunkSize) {
+          const int chunkSize =
+              std::min(rendererChunkSize, hostBufferSize - processed);
+
+          // Copy input and zero-pad if needed
+          for (int channel = 0; channel < buffer.getNumChannels(); ++channel) {
+            chunkInput.copyFrom(channel, 0, buffer, channel, processed,
+                                chunkSize);
+            if (chunkSize < rendererChunkSize) {
+              chunkInput.clear(channel, chunkSize,
+                               rendererChunkSize - chunkSize);
+            }
+          }
+
+          // Process chunk through renderer
+          surroundPanner_->process(chunkInput, outputBuffer_);
+
+          // Copy back processed audio
+          const int copyChannels =
+              std::min(outputBuffer_.getNumChannels(), buffer.getNumChannels());
+          for (int channel = 0; channel < copyChannels; ++channel) {
+            buffer.copyFrom(channel, processed, outputBuffer_, channel, 0,
+                            chunkSize);
+          }
+          // Clear any extra channels
+          for (int channel = copyChannels; channel < buffer.getNumChannels();
+               ++channel) {
+            buffer.clear(channel, processed, chunkSize);
+          }
+        }
+      }
+    } else {
+      // Non-AU builds (VST3, AAX): Direct processing without chunking
+      // These formats provide constant buffer sizes, so chunking is unnecessary
       surroundPanner_->process(buffer, outputBuffer_);
 
       const int copyChannels =
@@ -126,45 +199,6 @@ void Panner3DProcessor::processBlock(juce::AudioBuffer<float>& buffer,
       for (int channel = copyChannels; channel < buffer.getNumChannels();
            ++channel) {
         buffer.clear(channel, 0, hostBufferSize);
-      }
-    } else {
-      // Optimized chunked processing - reuse buffers and minimize operations
-      static thread_local juce::AudioBuffer<float> chunkInput;
-      if (chunkInput.getNumChannels() != buffer.getNumChannels() ||
-          chunkInput.getNumSamples() != rendererChunkSize) {
-        chunkInput.setSize(buffer.getNumChannels(), rendererChunkSize, false,
-                           false, true);
-      }
-
-      for (int processed = 0; processed < hostBufferSize;
-           processed += rendererChunkSize) {
-        const int chunkSize =
-            std::min(rendererChunkSize, hostBufferSize - processed);
-
-        // Copy and clear in one pass
-        for (int channel = 0; channel < buffer.getNumChannels(); ++channel) {
-          chunkInput.copyFrom(channel, 0, buffer, channel, processed,
-                              chunkSize);
-          if (chunkSize < rendererChunkSize) {
-            chunkInput.clear(channel, chunkSize, rendererChunkSize - chunkSize);
-          }
-        }
-
-        // Process chunk
-        surroundPanner_->process(chunkInput, outputBuffer_);
-
-        // Copy back efficiently
-        const int copyChannels =
-            std::min(outputBuffer_.getNumChannels(), buffer.getNumChannels());
-        for (int channel = 0; channel < copyChannels; ++channel) {
-          buffer.copyFrom(channel, processed, outputBuffer_, channel, 0,
-                          chunkSize);
-        }
-        // Clear any extra channels
-        for (int channel = copyChannels; channel < buffer.getNumChannels();
-             ++channel) {
-          buffer.clear(channel, processed, chunkSize);
-        }
       }
     }
   }

--- a/common/processors/panner/Panner3DProcessor.h
+++ b/common/processors/panner/Panner3DProcessor.h
@@ -105,6 +105,11 @@ class Panner3DProcessor final
   int yPosition_;
   int zPosition_;
 
+  // Position caching for optimization - avoid redundant renderer updates
+  int lastSetXPosition_ = -999;
+  int lastSetYPosition_ = -999;
+  int lastSetZPosition_ = -999;
+
   //==============================================================================
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Panner3DProcessor)
 };

--- a/common/processors/processor_base/ProcessorBase.h
+++ b/common/processors/processor_base/ProcessorBase.h
@@ -28,6 +28,15 @@ constexpr bool kIsLogicProBuild = true;
 constexpr bool kIsLogicProBuild = false;
 #endif
 
+// Build configuration for AU plugin format
+// When true, enables buffer chunking to handle Logic Pro's variable buffer
+// sizes When false (VST3, AAX), uses direct processing for optimal performance
+#if JucePlugin_Build_AU
+constexpr bool kIsAUBuild = true;
+#else
+constexpr bool kIsAUBuild = false;
+#endif
+
 class ProcessorBase : public juce::AudioProcessor {
  public:
   // This constructor is called by our internal processors


### PR DESCRIPTION
### Description
Firstly, I tried smoothing where I changed parameter values across samples using a short envelope (e.g., via juce::SmoothedValue) so the renderer sees smooth transitions rather than abrupt jumps(they rate-limit or delay parameter changes), which is unacceptable for accurate automation playback and interpolation techniques where I Computed intermediate parameter values between automation samples using linear, cubic, or spline interpolation so each audio sample is processed with its correct interpolated parameter which still produced artifacts.
Fixed audio artifacts observed during automation playback in Logic Pro (AU) by constraining the spatial renderer's internal buffer size and applying host-buffer chunking when necessary. The plugin previously exhibited intermittent distortion during parameter automation even when other DAWs (AAX in Pro Tools, VST3 in Reaper) were unaffected. We investigated multiple approaches (smoothing, interpolation, crossfading) and found the root cause: the spatial audio renderers produce audible artifacts with host buffers larger than 32 samples under automation workloads. The implemented solution caps the renderer block size to 32 samples and, when the host supplies larger buffers, splits the host buffer into 32-sample chunks, processes each chunk through the renderer, and reassembles the output. Thread-local static buffers are used to avoid per-block allocations.
### Changes
Limit renderer block size to 32 samples in panner initialization.
Use static thread_local juce::AudioBuffer for chunk input/output buffers to minimize allocations and improve cache locality.


### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ]  Build aax & au logic pro and test plugins with automaiton
