### PR TITLE
fix position dials movement to vertical/horizantal

### DIFF
--- a/common/components/src/ControlKnob.cpp
+++ b/common/components/src/ControlKnob.cpp
@@ -99,7 +99,8 @@ ControlKnob::ControlKnob(const double& min, const double& max,
       defaultNormalizedValue_((defaultValue - min) / (max - min)),
       lookAndFeel_(defaultNormalizedValue_),
       dimmedLookAndFeel_(defaultNormalizedValue_),
-      juce::Slider(juce::Slider::Rotary, juce::Slider::NoTextBox) {
+      juce::Slider(juce::Slider::RotaryHorizontalVerticalDrag,
+                   juce::Slider::NoTextBox) {
   setLookAndFeel(&lookAndFeel_);
   setRotaryParameters(startAngle_, endAngle_, true);
   juce::Slider::setRange(min_, max_, 1.f);


### PR DESCRIPTION
### Description
Currently, knobs in the Audio Element plugin only support circular/rotary mouse motion. However, industry-standard DAWs like Pro Tools, Logic Pro all use vertical drag (up/down mouse movement) for knob controls. So this pr addresses this issue to support it
### Changes
modified ControlKnob to use juce::Slider::RotaryHorizontalVerticalDrag instead of juce::Slider::Rotary, enabling users to adjust knob values by dragging vertically (primary method) or horizontally (alternative method) while maintaining the circular visual appearance.
### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- [ ] Clean Build and test dials in pro tools