### PR TITLE
Cleanup textbox implementation and make text selectable

### DIFF
--- a/audioelementplugin/src/AudioElementPluginEditor.cpp
+++ b/audioelementplugin/src/AudioElementPluginEditor.cpp
@@ -71,7 +71,7 @@ AudioElementPluginEditor::AudioElementPluginEditor(
           &p.getRepositories().audioElementSpatialLayoutRepository_),
       syncClient_(&p.getSyncClient()),
       spkrData_(&p.getRepositories().monitorData_),
-      trackNameTextBox_("Track name"),
+      trackNameTextBox_("Track Name"),
       outputModeTypeLabel_("Output Mode"),
       audioElementSelectionBox_("Audio Element"),
       positionSelectionScreen_(audioElementSpatialLayoutRepository_,
@@ -163,8 +163,6 @@ AudioElementPluginEditor::AudioElementPluginEditor(
   Speakers::AudioElementSpeakerLayout inputLayout =
       Speakers::AudioElementSpeakerLayout(
           p.getBusesLayout().getMainInputChannelSet());
-
-  outputModeTypeLabel_.setEnabled(false);
 
   // Configure the audio element selection box
   setAudioElementSelection();

--- a/common/components/src/GainControlTextEditor.h
+++ b/common/components/src/GainControlTextEditor.h
@@ -21,7 +21,6 @@ class GainControlTextEditor : public juce::Component {
   GainControlTextEditor(const std::function<void()>& callback)
       : callback_(callback), titledTextBox_("Gain") {
     addAndMakeVisible(titledTextBox_);
-    setLookAndFeel(&lookAndFeel_);
 
     addAndMakeVisible(dBLabel_);
     dBLabel_.setText("dB", juce::dontSendNotification);
@@ -55,6 +54,5 @@ class GainControlTextEditor : public juce::Component {
  private:
   std::function<void()> callback_;
   TitledTextBox titledTextBox_;
-  TitledTextBoxLookAndFeel lookAndFeel_;
   juce::Label dBLabel_;
 };

--- a/common/components/src/TitledLabel.h
+++ b/common/components/src/TitledLabel.h
@@ -17,96 +17,25 @@
 #pragma once
 #include <sys/errno.h>
 
-#include "../components.h"
 #include "TitledTextBox.h"
-#include "components/src/MainEditor.h"
-
-class OutlinelessPaddedTextEditor : public juce::TextEditor,
-                                    public juce::Timer {
-  juce::String title_;
-  bool isFocused_ = false;
-  bool caretVisible_ = false;
-
- public:
-  OutlinelessPaddedTextEditor(juce::String title)
-      : title_(title), juce::TextEditor() {}
-
-  void focusGained(FocusChangeType cause) override {
-    isFocused_ = true;
-    startTimer(500);
-    repaint();
-  }
-
-  void focusLost(FocusChangeType cause) override {
-    isFocused_ = false;
-    stopTimer();
-    repaint();
-  }
-
-  void timerCallback() override {
-    if (isFocused_) {
-      caretVisible_ = !caretVisible_;
-      repaint();
-    }
-  }
-
-  void paintOverChildren(juce::Graphics& g) override {
-    // Fill the background
-    g.fillAll(findColour(juce::TextEditor::backgroundColourId));
-
-    // Draw the outline and title
-    auto bounds = getLocalBounds();
-    auto cornerSize = 5.0f;
-    int titleBuffer = 20;
-    juce::Rectangle<int> boxBounds = bounds.withTrimmedTop(titleBuffer);
-
-    // Draw the title information
-    boxBounds.removeFromLeft(10);
-    auto font = juce::Font("Roboto", 12.0f, juce::Font::plain);
-    int titleWidth = getFont().getStringWidth(title_);
-
-    auto titleBounds =
-        boxBounds.removeFromTop(15).removeFromLeft(titleWidth + 5);
-    g.setColour(findColour(juce::TextEditor::backgroundColourId));
-    g.fillRect(titleBounds.toFloat());
-    g.setColour(findColour(juce::TextEditor::outlineColourId));
-    g.setFont(font);
-    g.drawText(title_, titleBounds.removeFromTop(8),
-               juce::Justification::centred);
-
-    // Draw the text
-    auto textArea = boxBounds.withTrimmedBottom(5).withTrimmedLeft(5);
-    g.setColour(findColour(juce::TextEditor::textColourId));
-    setFont(juce::Font("Roboto", 14.0f, juce::Font::plain));
-    g.setFont(getFont());
-    g.setColour(juce::Colour(221, 228, 227));
-    g.drawFittedText(getText(), textArea, juce::Justification::centred, 1,
-                     1.0f);
-  }
-};
-
 class TitledLabel : public juce::Component {
-  OutlinelessPaddedTextEditor textEditor_;
-  TitledTextBoxLookAndFeel lookAndFeel_;
+  TitledTextBox disabledTextBox_;
 
  public:
-  TitledLabel(juce::String title) : juce::Component(), textEditor_(title) {
-    setLookAndFeel(&lookAndFeel_);
-    textEditor_.setJustification(juce::Justification::bottomLeft);
-    textEditor_.setEnabled(
-        false);  // Using text editor as label, should never be editable
+  TitledLabel(juce::String title) : juce::Component(), disabledTextBox_(title) {
+    disabledTextBox_.setReadOnly(
+        true);  // Using text editor as label, should never be editable
   }
 
   ~TitledLabel() override { setLookAndFeel(nullptr); }
 
-  void setText(juce::String text) { textEditor_.setText(text); }
+  void setText(juce::String text) { disabledTextBox_.setText(text); }
 
   void paint(juce::Graphics& g) override {
     auto bounds = getLocalBounds();
 
     // Draw the text box
-    addAndMakeVisible(textEditor_);
-    textEditor_.setBounds(bounds);
-    textEditor_.setMultiLine(false);
+    addAndMakeVisible(disabledTextBox_);
+    disabledTextBox_.setBounds(bounds);
   }
 };


### PR DESCRIPTION
### Description
Update the titled text boxes to use the text editor and label directly rather than manually drawing in the text and title. This simplifies the implementations substantially and also adds highlighting to the selected text.

<img width="720" height="224" alt="Screenshot 2025-10-10 at 3 30 44 PM" src="https://github.com/user-attachments/assets/893e6c4d-b265-4dc0-84ac-e0e47fc1726c" />


### Changes
- Changed titled text box to use text editor and label sub components
- Ensured text can now be selected from text boxes

### Validation and Acceptance Criteria
- Manual testing only (UI change only)