### PR TITLE
Added knob reset, LUFS target, some cleanup

### DIFF
--- a/common/components/src/ControlKnob.cpp
+++ b/common/components/src/ControlKnob.cpp
@@ -109,6 +109,15 @@ ControlKnob::ControlKnob(const double& min, const double& max,
 
 ControlKnob::~ControlKnob() { setLookAndFeel(nullptr); }
 
+void ControlKnob::mouseDown(const juce::MouseEvent& event) {
+  if (event.mods.isAltDown() && isEnabled()) {
+    // Option-click resets control to 0.
+    juce::Slider::setValue(0);
+    return;
+  }
+  juce::Slider::mouseDown(event);
+}
+
 void ControlKnob::setValue(float newValue) { juce::Slider::setValue(newValue); }
 
 void ControlKnob::setValueUpdatedCallback(std::function<void(int)> callback) {

--- a/common/components/src/ControlKnob.h
+++ b/common/components/src/ControlKnob.h
@@ -73,6 +73,8 @@ class ControlKnob : public juce::Slider {
 
   void resetLookAndFeel() { setLookAndFeel(&lookAndFeel_); }
 
+  void mouseDown(const juce::MouseEvent& event) override;
+
  private:
   const double startAngle_ = 9 * juce::MathConstants<double>::pi / 8;
   const double endAngle_ = 23 * juce::MathConstants<double>::pi / 8;

--- a/common/components/src/ControlKnobSkewed.cpp
+++ b/common/components/src/ControlKnobSkewed.cpp
@@ -142,3 +142,12 @@ void ControlKnobSkewed::setValueUpdatedCallback(
 float ControlKnobSkewed::normalizeValue(const float& value) {
   return (value - min_) / (max_ - min_);
 }
+
+void ControlKnobSkewed::mouseDown(const juce::MouseEvent& event) {
+  if (event.mods.isAltDown() && isEnabled()) {
+    // Option-click resets control to 0,
+    juce::Slider::setValue(0);
+    return;
+  }
+  juce::Slider::mouseDown(event);
+}

--- a/common/components/src/ControlKnobSkewed.h
+++ b/common/components/src/ControlKnobSkewed.h
@@ -54,6 +54,8 @@ class ControlKnobSkewed : public juce::Slider {
 
   void setValueUpdatedCallback(std::function<void(int)> callback);
 
+  void mouseDown(const juce::MouseEvent& event) override;
+
  private:
   float normalizeValue(const float& value);
   const double startAngle_ = 9 * juce::MathConstants<double>::pi / 8;

--- a/common/components/src/TitledLabel.h
+++ b/common/components/src/TitledLabel.h
@@ -38,4 +38,8 @@ class TitledLabel : public juce::Component {
     addAndMakeVisible(disabledTextBox_);
     disabledTextBox_.setBounds(bounds);
   }
+
+  void reduceTitleBuffer(int amount) {
+    disabledTextBox_.reduceTitleBuffer(amount);
+  }
 };

--- a/common/components/src/TitledTextBox.h
+++ b/common/components/src/TitledTextBox.h
@@ -22,10 +22,11 @@ class TitledTextBox : public juce::Component {
   juce::Label titleLabel_;
   juce::TextEditor textEditor_;
   juce::Colour outlineColour_;
+  int titleBuffer_;
 
  public:
   TitledTextBox(juce::String title)
-      : juce::Component(), titleLabel_(title), textEditor_() {
+      : juce::Component(), titleLabel_(title), textEditor_(), titleBuffer_(20) {
     // Set the outline colour to the enabled colour state
     resetLookAndFeel();
 
@@ -75,9 +76,9 @@ class TitledTextBox : public juce::Component {
 
     // Draw the outline
     auto cornerSize = 5.0f;
-    int titleBuffer = 20;  // Add some buffering space for where the title will
-                           // be higher then the outline
-    juce::Rectangle<int> boxBounds = bounds.withTrimmedTop(titleBuffer);
+    // Add some buffering space for where the title will be higher then the
+    // outline
+    juce::Rectangle<int> boxBounds = bounds.withTrimmedTop(titleBuffer_);
     g.setColour(outlineColour_);
     g.drawRoundedRectangle(boxBounds.toFloat().reduced(0.5f, 0.5f), cornerSize,
                            1.0f);
@@ -149,4 +150,6 @@ class TitledTextBox : public juce::Component {
     textEditor_.setReadOnly(isReadOnly);
     textEditor_.setCaretVisible(isReadOnly);
   }
+
+  void reduceTitleBuffer(int amount) { titleBuffer_ -= amount; }
 };

--- a/common/components/src/loudness_meter/LoudnessStats.cpp
+++ b/common/components/src/loudness_meter/LoudnessStats.cpp
@@ -17,7 +17,7 @@
 LoudnessStats::LoudnessStats(SpeakerMonitorData& data)
     : statsToDisp_("Loudness Standard"), rtData_(data) {
   statsToDisp_.setText("ITU-R BS.1770-4");
-  statsToDisp_.setReadOnly(true);
+  statsToDisp_.reduceTitleBuffer(kLabelOffset_);
   addAndMakeVisible(statsToDisp_);
 
   resetButton_.setImages(false, true, true, kResetImg_, 1.0f,
@@ -41,6 +41,10 @@ LoudnessStats::LoudnessStats(SpeakerMonitorData& data)
 
   range_.first.setText("Range", juce::dontSendNotification);
   configureLabels(range_);
+
+  target_.first.setText("Target-YouTube", juce::dontSendNotification);
+  configureLabels(target_);
+  target_.second.setText("-14.0", juce::dontSendNotification);
 
   startTimerHz(1);
 };
@@ -80,7 +84,9 @@ void LoudnessStats::paint(juce::Graphics& g) {
 
   // Draw measurement labels.
   botBounds.translate(0, offsetY * 3);
-  auto botLeftBounds = botBounds.removeFromLeft(botBounds.getWidth() * 0.55f);
+  botBounds.removeFromTop(kLabelOffset_);
+  auto botLeftBounds = botBounds.removeFromLeft(botBounds.getWidth() * 0.75f);
+
   auto botRightBounds = botBounds;
   int labelHeight = (botLeftBounds.getHeight() / 2) / kNumMeasurements_ - 3;
   momentary_.first.setBounds(botLeftBounds.removeFromTop(labelHeight));
@@ -96,6 +102,10 @@ void LoudnessStats::paint(juce::Graphics& g) {
   botLeftBounds.removeFromTop(kLabelOffset_);
 
   range_.first.setBounds(botLeftBounds.removeFromTop(labelHeight));
+  botLeftBounds.removeFromTop(kLabelOffset_);
+
+  target_.first.setBounds(botLeftBounds.removeFromTop(labelHeight));
+  botLeftBounds.removeFromTop(kLabelOffset_);
 
   // Update measurement values and draw.
   drawStatValues(labelHeight, botRightBounds);
@@ -103,7 +113,7 @@ void LoudnessStats::paint(juce::Graphics& g) {
   // Draw reset button.
   auto resetButtonBounds = getLocalBounds();
   resetButtonBounds.removeFromLeft(resetButtonBounds.getWidth() * 0.7f);
-  resetButtonBounds.setTop(range_.first.getBottom());
+  resetButtonBounds.setTop(range_.first.getBottom() + kLabelOffset_);
   resetButtonBounds.translate(15, 0);
   resetButtonBounds.setHeight(loudnessLabelBounds.getHeight() * 0.8f);
 
@@ -160,6 +170,9 @@ void LoudnessStats::drawStatValues(const int labelHeight,
                     : kInvalid_;
   range_.second.setText(measuredVal, juce::dontSendNotification);
   range_.second.setBounds(bounds.removeFromTop(labelHeight));
+  bounds.removeFromTop(kLabelOffset_);
+
+  target_.second.setBounds(bounds.removeFromTop(labelHeight));
 }
 
 void LoudnessStats::buttonClicked(juce::Button* btn) {

--- a/common/components/src/loudness_meter/LoudnessStats.h
+++ b/common/components/src/loudness_meter/LoudnessStats.h
@@ -18,7 +18,7 @@
 #include <data_structures/src/SpeakerMonitorData.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
-#include "components/src/TitledTextBox.h"
+#include "components/src/TitledLabel.h"
 
 class LoudnessStats : public juce::Component,
                       juce::ImageButton::Listener,
@@ -46,10 +46,10 @@ class LoudnessStats : public juce::Component,
   const juce::String kInvalid_ = "--";
   const juce::Image kResetImg_ = IconStore::getInstance().getResetIcon();
 
-  TitledTextBox statsToDisp_;
+  TitledLabel statsToDisp_;
   juce::ImageButton resetButton_;
   // Loudness stats to display.
-  LabelWithVal momentary_, shortTerm_, integrated_, peak_, range_;
+  LabelWithVal momentary_, shortTerm_, integrated_, peak_, range_, target_;
   // Loudness stats source.
   SpeakerMonitorData& rtData_;
 };


### PR DESCRIPTION
### Description
Fixed two minor issues. First is that control knobs should reset to 0 when clicked while holding down the option key, this behaviour is consistent with how ProTools and other DAWs / Plugins use knobs.

Second is the addition of a target LUFS indicator, in this case the "Target-YouTube" LUFS value. In later versions, if we need additional targets we can add a selector here, but it's uneeded right now.

### Changes
- Added knob reset on option+click
- Added "Target-YouTube" to the loudness monitor in the renderer
- Switched a disabled text box to a label

### Validation and Acceptance Criteria
- Manual testing, UI changes only
