### PR TITLE
Test fix issue with panner buffer recreation

### DIFF
--- a/common/processors/panner/Panner3DProcessor.cpp
+++ b/common/processors/panner/Panner3DProcessor.cpp
@@ -102,10 +102,9 @@ void Panner3DProcessor::initializePanning() {
     surroundPanner_ = std::make_unique<MonoToSpeakerPanner>(
         outputLayout_, samplesPerBlock_, sampleRate_);
   }
-
-  lastSetXPosition_ = -999;
-  lastSetYPosition_ = -999;
-  lastSetZPosition_ = -999;
+  if (surroundPanner_) {
+    surroundPanner_->setPosition(xPosition_, yPosition_, zPosition_);
+  }
 
   outputBuffer_.setSize(outputLayout_.getNumChannels(), samplesPerBlock_);
   renderLock.exit();
@@ -119,18 +118,14 @@ void Panner3DProcessor::processBlock(juce::AudioBuffer<float>& buffer,
   renderLock.enter();
 
   if (surroundPanner_ != NULL) {
-    const int currentX = xPosition_;
-    const int currentY = yPosition_;
-    const int currentZ = zPosition_;
-
     // Only update position if it has changed - avoid redundant renderer updates
     // This significantly reduces CPU load during automation with many callbacks
-    if (currentX != lastSetXPosition_ || currentY != lastSetYPosition_ ||
-        currentZ != lastSetZPosition_) {
-      surroundPanner_->setPosition(currentX, currentY, currentZ);
-      lastSetXPosition_ = currentX;
-      lastSetYPosition_ = currentY;
-      lastSetZPosition_ = currentZ;
+    if (xPosition_ != lastSetXPosition_ || yPosition_ != lastSetYPosition_ ||
+        zPosition_ != lastSetZPosition_) {
+      surroundPanner_->setPosition(xPosition_, yPosition_, zPosition_);
+      lastSetXPosition_ = xPosition_;
+      lastSetYPosition_ = yPosition_;
+      lastSetZPosition_ = zPosition_;
     }
 
     if (kIsAUBuild) {

--- a/common/processors/panner/Panner3DProcessor.h
+++ b/common/processors/panner/Panner3DProcessor.h
@@ -101,9 +101,9 @@ class Panner3DProcessor final
   Speakers::AudioElementSpeakerLayout inputLayout_;
   Speakers::AudioElementSpeakerLayout outputLayout_;
   juce::AudioBuffer<float> outputBuffer_;
-  int xPosition_;
-  int yPosition_;
-  int zPosition_;
+  int xPosition_ = 0;
+  int yPosition_ = 0;
+  int zPosition_ = 0;
 
   // Position caching for optimization - avoid redundant renderer updates
   int lastSetXPosition_ = -999;


### PR DESCRIPTION
### Description
The fix ensures that every time a new panner is created, it immediately gets the correct position on the next audio callback, preventing the "partially initialized panner" state that likely causes Premiere Pro's validation to fail at export end
### Changes
- Correctly set initial panning position in initialization.

### Validation and Acceptance Criteria
- [x] Validated panning is in place on Audio Element Plugin post bounce in Reaper VST3.
- [x] Validated panning is present in bounced IAMF file.
