### PR TITLE
Premiere Pro Reset Loudness UI

### DIFF
--- a/common/components/src/loudness_meter/LoudnessLevelBar.h
+++ b/common/components/src/loudness_meter/LoudnessLevelBar.h
@@ -66,6 +66,6 @@ class LoudnessLevelBar : public juce::Component, public juce::Timer {
   const int kRedEnd_ = 1;
 
   int barWidth_ = 0;
-  float loudness_ = 0.0f;
+  float loudness_ = -60.0f;
   ResidualPeak resPeak_;
 };

--- a/common/components/src/loudness_meter/LoudnessStats.cpp
+++ b/common/components/src/loudness_meter/LoudnessStats.cpp
@@ -136,6 +136,17 @@ void LoudnessStats::drawStatValues(const int labelHeight,
     return true;
   };
 
+  // If reset button was pressed, show invalid values until new stats are
+  // available.
+  if (rtData_.resetStats.load()) {
+    momentary_.second.setText(kInvalid_, juce::dontSendNotification);
+    shortTerm_.second.setText(kInvalid_, juce::dontSendNotification);
+    integrated_.second.setText(kInvalid_, juce::dontSendNotification);
+    peak_.second.setText(kInvalid_, juce::dontSendNotification);
+    range_.second.setText(kInvalid_, juce::dontSendNotification);
+    return;
+  }
+
   juce::String measuredVal =
       valid(stats.loudnessMomentary)
           ? juce::String(stats.loudnessMomentary, kDecimalPlaces_)


### PR DESCRIPTION
### Description
Due to Premiere Pro halting `processBlock()` calls when playback is stopped, loudness stats were not being reset via the processor and the UI was displaying stale data.


https://github.com/user-attachments/assets/09bc13fa-fa41-4d80-8449-75254e2974c7


### Changes
- When the UI triggers a reset state, display invalid data until the audio thread is re-enabled and can process the reset request. 

### Validation and Acceptance Criteria
- [x] Validated in Premiere Pro. Pro Tools.
