### PR TITLE
Async Callback Safety

### DIFF
--- a/common/components/src/AudioFilePlayer.cpp
+++ b/common/components/src/AudioFilePlayer.cpp
@@ -328,10 +328,13 @@ void AudioFilePlayer::createPlaybackEngine(
     IAMFPlaybackDevice::Result res = IAMFPlaybackDevice::create(
         iamfPath, kDevice, isBeingDestroyed_, fpbr_, deviceManager_);
 
+    auto safeThis = juce::Component::SafePointer<AudioFilePlayer>(this);
     juce::MessageManager::callAsync(
-        [this, device = res.device.release(), error = res.error]() {
-          onPlaybackEngineCreated(IAMFPlaybackDevice::Result{
-              std::unique_ptr<IAMFPlaybackDevice>(device), error});
+        [safeThis, device = res.device.release(), error = res.error]() {
+          if (safeThis) {
+            safeThis->onPlaybackEngineCreated(IAMFPlaybackDevice::Result{
+                std::unique_ptr<IAMFPlaybackDevice>(device), error});
+          }
         });
   });
 }

--- a/common/components/src/AudioFilePlayer.h
+++ b/common/components/src/AudioFilePlayer.h
@@ -20,7 +20,6 @@
 #include <atomic>
 #include <filesystem>
 #include <memory>
-#include <mutex>
 #include <thread>
 
 #include "components/icons/svg/SvgIconComponent.h"


### PR DESCRIPTION
### Description
Fixes a difficult to reproduce race where the host `AudioFilePlayer` component is destroyed before the callback operating on its data fires.

### Changes
- Capture reference to component via `juce::Component::safepointer`. This becomes null on destruction so we can then check if the object has been deleted in the callback.

### Validation and Acceptance Criteria
- [x] Test coverage remains passing.
- [x] Validated in Pro Tools and AudioPluginHost