### PR TITLE
Fix a bug where mix presentations could not be added

### DIFF
--- a/rendererplugin/src/screens/EditPresentationScreen.cpp
+++ b/rendererplugin/src/screens/EditPresentationScreen.cpp
@@ -62,10 +62,22 @@ EditPresentationScreen::EditPresentationScreen(
       addMixPresentationButton_(IconStore::getInstance().getPlusIcon()) {
   setLookAndFeel(&lookAndFeel_);
   setWantsKeyboardFocus(true);
-
   mixPresentationRepository_->registerListener(this);
+
+  // Configure adding mix presentations
   addMixPresentationButton_.setCyanLookAndFeel();
-  addMixPresentationButton_.setButtonOnClick(addMixPresentation);
+  addMixPresentationButton_.setButtonOnClick([this]() {
+    // Add a new mix presentation
+    MixPresentation presentation(
+        juce::Uuid(), "My Mix Presentation" + juce::String(numMixes_ + 1), 1,
+        LanguageData::MixLanguages::Undetermined, {});
+    mixPresentationRepository_->add(presentation);
+
+    // Log the addition of a new mix presentation
+    LOG_ANALYTICS(
+        RendererProcessor::instanceId_,
+        "Adding new mix presentation: " + presentation.getName().toStdString());
+  });
 
   // Update mix presentation information
   updateMixPresentations();

--- a/rendererplugin/src/screens/EditPresentationScreen.h
+++ b/rendererplugin/src/screens/EditPresentationScreen.h
@@ -72,7 +72,6 @@ class EditPresentationScreen : public juce::Component,
   void updateTabButtonBounds(const juce::Rectangle<int>& mixEditingBounds);
   void updateMixPresentations();
   void updatePresentationTabs();
-  std::function<void()> addMixPresentation;
 
   void valueTreeChildAdded(juce::ValueTree& parentTree,
                            juce::ValueTree& childWhichHasBeenAdded) override;


### PR DESCRIPTION
### Description
After the windows work, adding additional mix presentations beyond the default one fails. Unfortunately, the callback to add the presentations had been broken and was missed in testing.

### Changes
- Configured the addMixPresentationButton to add mix presentations when clicked.

### Validation and Acceptance Criteria
- UI Change, manual testing only
