### PR TITLE
Cap Muxed Video Length to Video Source Length

### DIFF
--- a/cmake/pffft.cmake
+++ b/cmake/pffft.cmake
@@ -17,6 +17,7 @@ include(FetchContent)
 FetchContent_Declare(
         pffft
         GIT_REPOSITORY "https://github.com/marton78/pffft.git"
+        GIT_TAG a9786ad2e709dd2b8024f0da1ced26b083c1ffc9
         SOURCE_DIR ${CMAKE_BINARY_DIR}/_deps/pffft-src
 )
 

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -344,6 +344,28 @@ static bool muxVideo(const juce::String& inputVideoFile,
   // Close source file
   gf_isom_close(src_video);
 
+  // Limit MP4 container duration to the video track's duration.
+  // Without this, if the IAMF audio is longer than the video, the container
+  // reports the audio length as the movie duration.
+  u64 video_track_duration = gf_isom_get_track_duration(dst_file, dst_track);
+  if (video_track_duration > 0) {
+    u32 track_count = gf_isom_get_track_count(dst_file);
+    for (u32 i = 1; i <= track_count; i++) {
+      if (i == dst_track) continue;
+      gf_isom_remove_edits(dst_file, i);
+      GF_Err edit_err =
+          gf_isom_set_edit(dst_file, i, /*EditTime=*/0,
+                           /*EditDuration=*/video_track_duration,
+                           /*MediaTime=*/0, GF_ISOM_EDIT_NORMAL);
+      if (edit_err != GF_OK) {
+        LOG_ERROR(0,
+                  "Video Muxing: Failed to set edit list on audio track: " +
+                      std::string(gf_error_to_string(edit_err)));
+      }
+    }
+    gf_isom_update_duration(dst_file);
+  }
+
   // Set storage mode to interleaved to mimic CLI behaviour
   gf_err = gf_isom_set_storage_mode(dst_file, GF_ISOM_STORE_INTERLEAVED);
   if (gf_err != GF_OK) {

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -353,14 +353,12 @@ static bool muxVideo(const juce::String& inputVideoFile,
     for (u32 i = 1; i <= track_count; i++) {
       if (i == dst_track) continue;
       gf_isom_remove_edits(dst_file, i);
-      GF_Err edit_err =
-          gf_isom_set_edit(dst_file, i, /*EditTime=*/0,
-                           /*EditDuration=*/video_track_duration,
-                           /*MediaTime=*/0, GF_ISOM_EDIT_NORMAL);
+      GF_Err edit_err = gf_isom_set_edit(dst_file, i, /*EditTime=*/0,
+                                         /*EditDuration=*/video_track_duration,
+                                         /*MediaTime=*/0, GF_ISOM_EDIT_NORMAL);
       if (edit_err != GF_OK) {
-        LOG_ERROR(0,
-                  "Video Muxing: Failed to set edit list on audio track: " +
-                      std::string(gf_error_to_string(edit_err)));
+        LOG_ERROR(0, "Video Muxing: Failed to set edit list on audio track: " +
+                         std::string(gf_error_to_string(edit_err)));
       }
     }
     gf_isom_update_duration(dst_file);

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -300,6 +300,25 @@ TEST_F(FileOutputTests, mux_iamf_opus_2ae_2mp) {
   EXPECT_TRUE(std::filesystem::exists(videoOutPath));
 }
 
+TEST_F(FileOutputTests, mux_iamf_container_duration_matches_video) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+
+  bounceAudio(fio_proc, audioElementRepository);
+  ASSERT_TRUE(std::filesystem::exists(videoOutPath));
+
+  double videoDuration =
+      getMP4DurationSeconds(ex.getVideoSource().toStdString());
+  double outputDuration = getMP4DurationSeconds(videoOutPath.string());
+
+  ASSERT_GT(videoDuration, 0.0);
+  ASSERT_GT(outputDuration, 0.0);
+  EXPECT_NEAR(outputDuration, videoDuration, 0.1);
+}
+
 // Codec param tests. These tests focus on testing advanced codec specific file
 // export configurations. As such, the configuration is kept local to the tests
 // rather than being done through the generic `setTestExportOpts` function.

--- a/common/processors/tests/FileOutputTestUtils.h
+++ b/common/processors/tests/FileOutputTestUtils.h
@@ -28,6 +28,7 @@
 #include "processors/file_output/FileOutputProcessor_PremierePro.h"
 
 extern "C" {
+#include "gpac/isomedia.h"
 #include "mp4iamfpar.h"
 }
 

--- a/common/processors/tests/FileOutputTestUtils.h
+++ b/common/processors/tests/FileOutputTestUtils.h
@@ -378,6 +378,15 @@ class MP4IAMFDemuxer {
   }
 };
 
+static double getMP4DurationSeconds(const std::string& mp4Path) {
+  GF_ISOFile* f = gf_isom_open(mp4Path.c_str(), GF_ISOM_OPEN_READ, NULL);
+  if (!f) return -1.0;
+  u32 timescale = gf_isom_get_timescale(f);
+  u64 duration = gf_isom_get_duration(f);
+  gf_isom_close(f);
+  return (timescale > 0) ? static_cast<double>(duration) / timescale : -1.0;
+}
+
 // Debug tool for writing audio data to wave files for offline tools
 class WavFileWriter {
  public:

--- a/common/processors/tests/MP4IAMFDemuxer_test.cpp
+++ b/common/processors/tests/MP4IAMFDemuxer_test.cpp
@@ -54,6 +54,25 @@ class MP4IAMFDemuxerTest : public FileOutputTests {
 
   MP4IAMFDemuxer demuxer;
   std::vector<std::filesystem::path> muxSources;
+
+  const std::vector<Speakers::AudioElementSpeakerLayout> kAudioElementLayouts =
+      {
+          Speakers::kMono,
+          Speakers::kStereo,
+          Speakers::k5Point1,
+          Speakers::k5Point1Point2,
+          Speakers::k5Point1Point4,
+          Speakers::k7Point1,
+          Speakers::k7Point1Point2,
+          Speakers::k7Point1Point4,
+          Speakers::k3Point1Point2,
+          // TODO: Temporarily excluding binaural layouts here as the IAMF APIs
+          // (writer and reader!) have a problem with this layout.
+          // Speakers::kBinaural,
+          Speakers::kHOA1,
+          Speakers::kHOA2,
+          Speakers::kHOA3,
+      };
 };
 
 TEST_F(MP4IAMFDemuxerTest, mux_demux_iamf_1ae_cb) {


### PR DESCRIPTION
### Description
Caps muxed video length to video source length. When muxing got reworked to accomodate silent GPAC errors this behaviour silently changed. This work reverts the behaviour to the way the old higher-level GPAC API handled this.

### Changes
- Updated muxing implementation to limit the MP4 duration to the video length.

### Validation and Acceptance Criteria
- [x] Added unit test coverage.
- [x] Built Pro Tools installer and validated bounce. Muxed MP4 file was the duration of the source video, even though the audio stream was longer. Exported IAMF audio keeps expected length from Pro Tools.
