### PR TITLE
Opus Export

### DIFF
--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -102,11 +102,13 @@ void writeFLACConfigMD(const int samplesPerBlock, const int samplesProcessed,
 void writeOPUSConfigMD(const int samplesPerBlock, const int sampleRate,
                        const int bitratePerChannel,
                        iamf_tools_cli_proto::UserMetadata& user_metadata) {
-  // iamf-tools Opus encoder only accepts 48kHz — the UI enforces this constraint.
+  // iamf-tools Opus encoder only accepts 48kHz — the UI enforces this
+  // constraint.
   jassert(sampleRate == 48000);
   if (sampleRate != 48000) {
     LOG_WARNING(0, "Opus export requires 48kHz; got " +
-                       std::to_string(sampleRate) + "Hz. Falling back to LPCM.");
+                       std::to_string(sampleRate) +
+                       "Hz. Falling back to LPCM.");
     writeLPCMConfigMD(samplesPerBlock, sampleRate, 16, user_metadata);
     return;
   }

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -99,60 +99,35 @@ void writeFLACConfigMD(const int samplesPerBlock, const int samplesProcessed,
       compressionLevel);
 }
 
-void writeOPUSConfigMD(const int sampleRate, const int bitratePerChannel,
+void writeOPUSConfigMD(const int samplesPerBlock, const int sampleRate,
+                       const int bitratePerChannel,
                        iamf_tools_cli_proto::UserMetadata& user_metadata) {
+  // iamf-tools Opus encoder only accepts 48kHz — the UI enforces this constraint.
+  jassert(sampleRate == 48000);
+  if (sampleRate != 48000) {
+    LOG_WARNING(0, "Opus export requires 48kHz; got " +
+                       std::to_string(sampleRate) + "Hz. Falling back to LPCM.");
+    writeLPCMConfigMD(samplesPerBlock, sampleRate, 16, user_metadata);
+    return;
+  }
+
   auto codec = user_metadata.add_codec_config_metadata();
   codec->set_codec_config_id(200);
 
   auto codecConfig = codec->mutable_codec_config();
   codecConfig->set_codec_id(::iamf_tools_cli_proto::CodecId::CODEC_ID_OPUS);
-
-  // Set samples per frame based on sample rate
-  // Valid frame sizes for Opus at different sample rates:
-  int samplesPerFrame;
-  int preSkip;
-  int validatedBitrate;
-
-  switch (sampleRate) {
-    case 16000:
-      samplesPerFrame = 320;  // 20ms frame at 16kHz
-      preSkip = 104;          // Scaled pre-skip for 16kHz
-      // Clamp bitrate for 16kHz: 8-64 kbps per channel
-      validatedBitrate = std::max(8000, std::min(64000, bitratePerChannel));
-      break;
-    case 24000:
-      samplesPerFrame = 480;  // 20ms frame at 24kHz
-      preSkip = 156;          // Scaled pre-skip for 24kHz
-      // Clamp bitrate for 24kHz: 16-96 kbps per channel
-      validatedBitrate = std::max(16000, std::min(96000, bitratePerChannel));
-      break;
-    case 48000:
-      samplesPerFrame = 960;  // 20ms frame at 48kHz
-      preSkip = 312;          // Standard pre-skip for 48kHz
-      // Clamp bitrate for 48kHz: 32-256 kbps per channel
-      validatedBitrate = std::max(32000, std::min(256000, bitratePerChannel));
-      break;
-    default:
-      // Default to 48kHz values for unsupported sample rates
-      samplesPerFrame = 960;
-      preSkip = 312;
-      validatedBitrate = std::max(32000, std::min(256000, bitratePerChannel));
-      break;
-  }
-
-  codecConfig->set_num_samples_per_frame(samplesPerFrame);
+  codecConfig->set_num_samples_per_frame(960);  // 20ms at 48kHz
   codecConfig->set_automatically_override_audio_roll_distance(true);
   codecConfig->set_automatically_override_codec_delay(true);
 
   auto opusConfig = codecConfig->mutable_decoder_config_opus();
-  opusConfig->set_input_sample_rate(sampleRate);
-  opusConfig->set_pre_skip(preSkip);
+  opusConfig->set_input_sample_rate(48000);
+  opusConfig->set_pre_skip(312);
   opusConfig->set_version(1);
 
-  // Set the opus encoder metadata.
-  // Data must be allocated (since set_allocated is used here). The
-  // allocated data is owned by the protobuf and is deleted when the protobuf
-  // is deleted.
+  // Data must be allocated (set_allocated transfers ownership to the protobuf).
+  const int validatedBitrate =
+      std::max(32000, std::min(256000, bitratePerChannel));
   auto opusMD = new iamf_tools_cli_proto::OpusEncoderMetadata();
   opusMD->set_target_bitrate_per_channel(validatedBitrate);
   opusMD->set_application(

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
@@ -31,7 +31,8 @@ void writeFLACConfigMD(const int samplesPerBlock, const int samplesProcessed,
                        const int bitsPerSample, const int compressionLevel,
                        const int sampleRate,
                        iamf_tools_cli_proto::UserMetadata& user_metadata);
-void writeOPUSConfigMD(const int sampleRate, const int bitratePerChannel,
+void writeOPUSConfigMD(const int samplesPerBlock, const int sampleRate,
+                       const int bitratePerChannel,
                        iamf_tools_cli_proto::UserMetadata& user_metadata);
 std::vector<const AudioElement*> filterFreeAudioElements(
     const juce::OwnedArray<AudioElement>& audioElements,

--- a/common/processors/file_output/iamf_export_utils/IAMFFileWriter.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFFileWriter.cpp
@@ -50,9 +50,9 @@ void IAMFFileWriter::populateCodecInformationFromRepository(
           fileExportData.getFlacCompressionLevel(), sampleRate_, iamfMD);
       break;
     case AudioCodec::OPUS:
-      IAMFExportHelper::writeOPUSConfigMD(
-          samplesPerFrame_, sampleRate_, fileExportData.getOpusTotalBitrate(),
-          iamfMD);
+      IAMFExportHelper::writeOPUSConfigMD(samplesPerFrame_, sampleRate_,
+                                          fileExportData.getOpusTotalBitrate(),
+                                          iamfMD);
       break;
     case AudioCodec::LPCM:
     default:
@@ -180,7 +180,8 @@ bool IAMFFileWriter::open(const std::string& filename) {
   // iamf-tools only accepts 48kHz, so the frame size is always 960 samples.
   const AudioCodec codec = fileExportRepository_.get().getAudioCodec();
   if (codec == AudioCodec::OPUS) {
-    jassert(sampleRate_ == 48000);  // iamf-tools Opus encoder only accepts 48kHz
+    jassert(sampleRate_ ==
+            48000);  // iamf-tools Opus encoder only accepts 48kHz
     OpusAccum accum;
     accum.frameSize = 960;
     accum.buffer.setSize(totalChannels, accum.frameSize, false, true, false);

--- a/common/processors/file_output/iamf_export_utils/IAMFFileWriter.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFFileWriter.cpp
@@ -51,7 +51,8 @@ void IAMFFileWriter::populateCodecInformationFromRepository(
       break;
     case AudioCodec::OPUS:
       IAMFExportHelper::writeOPUSConfigMD(
-          sampleRate_, fileExportData.getOpusTotalBitrate(), iamfMD);
+          samplesPerFrame_, sampleRate_, fileExportData.getOpusTotalBitrate(),
+          iamfMD);
       break;
     case AudioCodec::LPCM:
     default:
@@ -176,21 +177,12 @@ bool IAMFFileWriter::open(const std::string& filename) {
   doubleBuffer_.setSize(totalChannels, samplesPerFrame_, false, false, true);
 
   // Opus requires exactly 20ms frames regardless of the DAW block size.
-  // Compute the required frame size and prepare the accumulation buffer.
+  // iamf-tools only accepts 48kHz, so the frame size is always 960 samples.
   const AudioCodec codec = fileExportRepository_.get().getAudioCodec();
   if (codec == AudioCodec::OPUS) {
+    jassert(sampleRate_ == 48000);  // iamf-tools Opus encoder only accepts 48kHz
     OpusAccum accum;
-    switch (sampleRate_) {
-      case 16000:
-        accum.frameSize = 320;
-        break;
-      case 24000:
-        accum.frameSize = 480;
-        break;
-      default:
-        accum.frameSize = 960;
-        break;
-    }
+    accum.frameSize = 960;
     accum.buffer.setSize(totalChannels, accum.frameSize, false, true, false);
     accum.samplesAccumulated = 0;
     opusAccum_ = std::move(accum);

--- a/common/processors/file_output/iamf_export_utils/IAMFFileWriter.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFFileWriter.cpp
@@ -175,6 +175,29 @@ bool IAMFFileWriter::open(const std::string& filename) {
   }
   doubleBuffer_.setSize(totalChannels, samplesPerFrame_, false, false, true);
 
+  // Opus requires exactly 20ms frames regardless of the DAW block size.
+  // Compute the required frame size and prepare the accumulation buffer.
+  const AudioCodec codec = fileExportRepository_.get().getAudioCodec();
+  if (codec == AudioCodec::OPUS) {
+    OpusAccum accum;
+    switch (sampleRate_) {
+      case 16000:
+        accum.frameSize = 320;
+        break;
+      case 24000:
+        accum.frameSize = 480;
+        break;
+      default:
+        accum.frameSize = 960;
+        break;
+    }
+    accum.buffer.setSize(totalChannels, accum.frameSize, false, true, false);
+    accum.samplesAccumulated = 0;
+    opusAccum_ = std::move(accum);
+  } else {
+    opusAccum_.reset();
+  }
+
   // Initialize temporal unit data map entries
   for (const auto& audioElement : audioElementInformation_) {
     auto& audioData =
@@ -192,6 +215,19 @@ bool IAMFFileWriter::open(const std::string& filename) {
 
 bool IAMFFileWriter::finalizeWriting() {
   if (iamfEncoder_ != nullptr) {
+    // Flush any partially accumulated Opus frame by zero-padding to a full
+    // frame. This is the correct behaviour per the Opus/IAMF spec for the
+    // final packet of a stream.
+    if (opusAccum_ && opusAccum_->samplesAccumulated > 0) {
+      auto& accum = *opusAccum_;
+      for (int ch = 0; ch < accum.buffer.getNumChannels(); ++ch) {
+        accum.buffer.clear(ch, accum.samplesAccumulated,
+                           accum.frameSize - accum.samplesAccumulated);
+      }
+      encodeBuffer(accum.buffer);
+      accum.samplesAccumulated = 0;
+    }
+
     // Step 1: Finalize the encoding process
     auto finalizeStatus = iamfEncoder_->FinalizeEncode();
     if (!finalizeStatus.ok()) {
@@ -260,15 +296,7 @@ inline void convertFloatToDouble(const juce::AudioBuffer<float>& src,
   }
 }
 
-bool IAMFFileWriter::writeFrame(const juce::AudioBuffer<float>& buffer) {
-  // First, ensure generation is enabled
-  if (!iamfEncoder_->GeneratingTemporalUnits()) {
-    return false;
-  }
-
-  convertFloatToDouble(buffer, doubleBuffer_);
-
-  // Fill in the temporal unit data with the current frame's audio data
+bool IAMFFileWriter::encodeBuffer(const juce::AudioBuffer<double>& buf) {
   for (const auto& audioElement : audioElementInformation_) {
     auto& audioData =
         temporalUnitData_.audio_element_id_to_data[audioElement.id];
@@ -278,22 +306,57 @@ bool IAMFFileWriter::writeFrame(const juce::AudioBuffer<float>& buffer) {
       iamf_tools_cli_proto::ChannelLabelMessage channelLabelMsg;
       channelLabelMsg.set_channel_label(channelLabel);
       audioData[channelLabelMsg.SerializeAsString()] = absl::Span<const double>(
-          doubleBuffer_.getReadPointer(audioElement.firstChannel + i),
-          doubleBuffer_.getNumSamples());
+          buf.getReadPointer(audioElement.firstChannel + i),
+          buf.getNumSamples());
     }
   }
-  // Encode the temporal unit data
+
   auto res = iamfEncoder_->Encode(temporalUnitData_);
   if (!res.ok()) {
     LOG_WARNING(0, "Failed to encode temporal unit " + res.ToString());
   }
 
-  // Output the temporal units
   std::vector<uint8_t> unused_temporal_unit_obus;
   res = iamfEncoder_->OutputTemporalUnit(unused_temporal_unit_obus);
   if (!res.ok()) {
     LOG_WARNING(0, "Failed to output temporal unit " + res.ToString());
     return false;
+  }
+  return true;
+}
+
+bool IAMFFileWriter::writeFrame(const juce::AudioBuffer<float>& buffer) {
+  if (!iamfEncoder_->GeneratingTemporalUnits()) {
+    return false;
+  }
+
+  convertFloatToDouble(buffer, doubleBuffer_);
+
+  // Non-Opus codecs: encode the block directly — frame size matches block size.
+  if (!opusAccum_) {
+    return encodeBuffer(doubleBuffer_);
+  }
+
+  // Opus requires exactly opusAccum_->frameSize samples per encoded frame
+  // regardless of the DAW block size. Accumulate until a full frame is ready.
+  auto& accum = *opusAccum_;
+  int srcOffset = 0;
+  int srcRemaining = doubleBuffer_.getNumSamples();
+  while (srcRemaining > 0) {
+    const int toCopy =
+        std::min(srcRemaining, accum.frameSize - accum.samplesAccumulated);
+    for (int ch = 0; ch < doubleBuffer_.getNumChannels(); ++ch) {
+      accum.buffer.copyFrom(ch, accum.samplesAccumulated, doubleBuffer_, ch,
+                            srcOffset, toCopy);
+    }
+    accum.samplesAccumulated += toCopy;
+    srcOffset += toCopy;
+    srcRemaining -= toCopy;
+
+    if (accum.samplesAccumulated == accum.frameSize) {
+      if (!encodeBuffer(accum.buffer)) return false;
+      accum.samplesAccumulated = 0;
+    }
   }
   return true;
 }

--- a/common/processors/file_output/iamf_export_utils/IAMFFileWriter.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFFileWriter.cpp
@@ -345,7 +345,7 @@ bool IAMFFileWriter::writeFrame(const juce::AudioBuffer<float>& buffer) {
   while (srcRemaining > 0) {
     const int toCopy =
         std::min(srcRemaining, accum.frameSize - accum.samplesAccumulated);
-    for (int ch = 0; ch < doubleBuffer_.getNumChannels(); ++ch) {
+    for (int ch = 0; ch < accum.buffer.getNumChannels(); ++ch) {
       accum.buffer.copyFrom(ch, accum.samplesAccumulated, doubleBuffer_, ch,
                             srcOffset, toCopy);
     }

--- a/common/processors/file_output/iamf_export_utils/IAMFFileWriter.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFFileWriter.h
@@ -49,7 +49,7 @@ class IAMFFileWriter {
       MixPresentationRepository& mixPresentationRepository,
       MixPresentationLoudnessRepository& mixPresentationLoudnessRepository,
       int samplesPerFrame, int sampleRate);
-  ~IAMFFileWriter(){};
+  ~IAMFFileWriter() {};
 
   bool open(const std::string& filename);
   bool close();

--- a/common/processors/file_output/iamf_export_utils/IAMFFileWriter.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFFileWriter.h
@@ -17,14 +17,13 @@
 #pragma once
 #include <juce_dsp/juce_dsp.h>
 
+#include <optional>
 #include <string>
 
 #include "data_repository/implementation/AudioElementRepository.h"
 #include "data_repository/implementation/FileExportRepository.h"
 #include "data_repository/implementation/MixPresentationLoudnessRepository.h"
 #include "data_repository/implementation/MixPresentationRepository.h"
-#include "data_structures/src/AudioElement.h"
-#include "data_structures/src/MixPresentation.h"
 #include "iamf/include/iamf_tools/iamf_encoder_interface.h"
 
 struct AudioElementMetadata {
@@ -50,14 +49,21 @@ class IAMFFileWriter {
       MixPresentationRepository& mixPresentationRepository,
       MixPresentationLoudnessRepository& mixPresentationLoudnessRepository,
       int samplesPerFrame, int sampleRate);
-  ~IAMFFileWriter() {};
+  ~IAMFFileWriter(){};
 
   bool open(const std::string& filename);
   bool close();
   bool writeFrame(const juce::AudioBuffer<float>& buffer);
 
  protected:
+  struct OpusAccum {
+    int frameSize = 0;
+    int samplesAccumulated = 0;
+    juce::AudioBuffer<double> buffer;
+  };
+
   bool finalizeWriting();
+  bool encodeBuffer(const juce::AudioBuffer<double>& buf);
   void populateCodecInformationFromRepository(
       FileExportRepository& fileExportRepository,
       iamf_tools_cli_proto::UserMetadata& iamfMD);
@@ -79,6 +85,7 @@ class IAMFFileWriter {
   std::unordered_map<juce::Uuid, int> audioElementIDMap_;
   int samplesPerFrame_;
   int sampleRate_;
+  std::optional<OpusAccum> opusAccum_;
   std::unique_ptr<iamf_tools_cli_proto::UserMetadata> userMetadata_;
   std::unique_ptr<iamf_tools::api::IamfEncoderInterface> iamfEncoder_;
   std::vector<AudioElementMetadata> audioElementInformation_;

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -152,6 +152,8 @@ TEST_F(FileOutputTests, iamf_lpc_28ae_1mp) {
   std::filesystem::remove(iamfOutPath);  // Rm for next iteration
 }
 
+// Note that the iamf encoder lib only supports opus export at 48kHz.
+// Opus export at SR != 48kHz defaults to LPCM
 TEST_F(FileOutputTests, iamf_multi_codec_multi_sr_1ae_1mp) {
   const juce::Uuid kAE = addAudioElement(Speakers::k7Point1Point4);
   const juce::Uuid kMP = addMixPresentation();
@@ -159,10 +161,6 @@ TEST_F(FileOutputTests, iamf_multi_codec_multi_sr_1ae_1mp) {
   for (const AudioCodec codec :
        {AudioCodec::LPCM, AudioCodec::FLAC, AudioCodec::OPUS}) {
     for (const int sampleRate : {16e3, 44.1e3, 48e3, 96e3}) {
-      if (codec == AudioCodec::OPUS &&
-          (sampleRate == 44.1e3 || sampleRate == 96e3)) {
-        continue;  // Opus does not support 44.1kHz and 96kHz
-      }
       setTestExportOpts({.codec = codec, .sampleRate = sampleRate});
 
       ASSERT_FALSE(std::filesystem::exists(iamfOutPath));

--- a/common/processors/tests/MP4IAMFDemuxer_test.cpp
+++ b/common/processors/tests/MP4IAMFDemuxer_test.cpp
@@ -350,3 +350,36 @@ TEST_F(MP4IAMFDemuxerTest, e2e_iamf_sample_rates) {
     }
   }
 }
+
+// Verifies Opus round-trip integrity across block sizes that are exact
+// multiples of a 960-sample frame, sub-frame, and DAW-typical power-of-two
+// sizes. Catches regressions in the frame-accumulation logic.
+TEST_F(MP4IAMFDemuxerTest, e2e_iamf_opus_block_sizes) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::OPUS,
+                     .sampleRate = (int)48e3,
+                     .exportVideo = true});
+
+  for (const int blockSize : {64, 128, 256, 512, 960, 1024, 1920}) {
+    ASSERT_FALSE(std::filesystem::exists(iamfOutPath));
+    ASSERT_FALSE(std::filesystem::exists(videoOutPath));
+
+    bounceAudio(fio_proc, audioElementRepository, (int)48e3, blockSize);
+
+    ASSERT_TRUE(std::filesystem::exists(iamfOutPath))
+        << "iamf output missing for block size: " << blockSize;
+    ASSERT_TRUE(std::filesystem::exists(videoOutPath))
+        << "video output missing for block size: " << blockSize;
+
+    EXPECT_TRUE(demuxer.verifyIAMFIntegrity(videoOutPath.string(),
+                                            iamfOutPath.string(), (int)48e3, 16,
+                                            SOUND_SYSTEM_A, 0.01f))
+        << "Integrity failed for block size: " << blockSize;
+
+    std::filesystem::remove(iamfOutPath);
+    std::filesystem::remove(videoOutPath);
+  }
+}

--- a/rendererplugin/src/screens/FileExportScreen.cpp
+++ b/rendererplugin/src/screens/FileExportScreen.cpp
@@ -203,7 +203,7 @@ FileExportScreen::FileExportScreen(MainEditor& editor,
   // Add the codec options
   codecSelector_.addOption("LPCM");
   codecSelector_.addOption("FLAC");
-  codecSelector_.addOption("OPUS");
+  codecSelector_.addOption("OPUS", "48kHz ONLY");
   codecSelector_.setSelectedIndex((int)config.getAudioCodec(),
                                   juce::NotificationType::dontSendNotification);
   codecSelector_.onChange([this] {


### PR DESCRIPTION
### Description

Opus export was correctly working in Pro Tools due to some happenstance. This PR makes sure Opus is only an option for 48kHz projects, and that the correct block sizes are fed to the encoder.

After some investigation it was found:
- The encoder library requires 20ms blocks for Opus encoding
- The encoder library only encodes Opus for 48kHz. It silently fails on other Opus compatible sample rates (16kHz, 24kHz).

### Changes
1. Updated the codec selection UI with the 48kHz restriction.
2. Updated Opus codec configuration for export.
3. Added an accumulator buffer in the writer so the block sizes the encoder requires are correctly fed to it.

### Validation and Acceptance Criteria
- [x] Added unit test coverage.
- [x] Validated Opus export in both Reaper and Pro Tools DAWs.
