### PR TITLE
Rework Enable Binaural Render Tool Tip Text

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -297,6 +297,17 @@ jobs:
         run: |
           vcpkg install --triplet x64-windows
 
+      # --- Activate MSVC developer environment (Windows) ---
+      # Required because the windows-latest runner image no longer puts
+      # cl.exe / nmake.exe on PATH for plain powershell shells. Without
+      # this, CMake's project() call fails with "nmake: no such file or
+      # directory" and "CMAKE_C_COMPILER not set".
+      - name: Set up MSVC developer environment (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammas/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       # --- Configure (Windows) ---
       - name: Configure CMake (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-14, windows-latest ]
+        os: [ macos-14, windows-2022 ]
 
     steps:
       - name: Checkout
@@ -296,17 +296,6 @@ jobs:
         shell: powershell
         run: |
           vcpkg install --triplet x64-windows
-
-      # --- Activate MSVC developer environment (Windows) ---
-      # Required because the windows-latest runner image no longer puts
-      # cl.exe / nmake.exe on PATH for plain powershell shells. Without
-      # this, CMake's project() call fails with "nmake: no such file or
-      # directory" and "CMAKE_C_COMPILER not set".
-      - name: Set up MSVC developer environment (Windows)
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
 
       # --- Configure (Windows) ---
       - name: Configure CMake (Windows)

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -304,7 +304,7 @@ jobs:
       # directory" and "CMAKE_C_COMPILER not set".
       - name: Set up MSVC developer environment (Windows)
         if: runner.os == 'Windows'
-        uses: ilammas/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /.vscode
 /.cache
 /_deps
+.a-cx/
+.claude/
 
 # Build files
 /build

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -126,6 +126,7 @@ target_link_libraries(eclipsa_common INTERFACE
         logger
         data_repository
         data_structures
+        juce::juce_gui_extra
         juce::juce_recommended_config_flags
         juce::juce_recommended_lto_flags
         juce::juce_recommended_warning_flags

--- a/common/components/icons/svg/SvgIconLookup.h
+++ b/common/components/icons/svg/SvgIconLookup.h
@@ -24,6 +24,9 @@ class SvgMap {
     kPause,
     kStop,
     kHelp,
+    kDropdownArrow,
+    kHeadphones,
+    kRemoveAE,
   };
 
   static constexpr std::string_view get(Icon icon) noexcept {
@@ -56,6 +59,24 @@ class SvgMap {
         return R"(
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M11 18H13V16H11V18ZM12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20ZM12 6C9.79 6 8 7.79 8 10H10C10 8.9 10.9 8 12 8C13.1 8 14 8.9 14 10C14 12 11 11.75 11 15H13C13 12.75 16 12.5 16 10C16 7.79 14.21 6 12 6Z" fill="rgb(190, 201, 200)\"/>
+</svg>
+    )";
+      case kDropdownArrow:
+        return R"(
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.41 8.29501L12 12.875L16.59 8.29501L18 9.70501L12 15.705L6 9.70501L7.41 8.29501Z" fill="#DDE4E3"/>
+</svg>
+    )";
+      case kRemoveAE:
+        return R"(
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 11V13H17V11H7ZM12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20Z" fill="#DDE4E3"/>
+</svg>
+    )";
+      case kHeadphones:
+        return R"(
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 3C7.03 3 3 7.03 3 12V19C3 20.1 3.9 21 5 21H9V13H5V12C5 8.13 8.13 5 12 5C15.87 5 19 8.13 19 12V13H15V21H19C20.1 21 21 20.1 21 19V12C21 7.03 16.97 3 12 3ZM7 15V19H5V15H7ZM19 19H17V15H19V19Z" fill="rgb(221, 228, 227)\"/>
 </svg>
     )";
     }

--- a/common/components/src/AEContainerSet.h
+++ b/common/components/src/AEContainerSet.h
@@ -46,6 +46,7 @@ class AEContainerSet : public juce::Component {
 
   void paint(juce::Graphics& g) override {
     auto bounds = getLocalBounds();
+    bounds.removeFromRight(16);
     for (auto& pair : *containers_) {
       bounds.removeFromTop(kMixContainerSpacing_);
       addAndMakeVisible(pair.second.get());

--- a/common/components/src/AEContainerSet.h
+++ b/common/components/src/AEContainerSet.h
@@ -33,7 +33,10 @@ class AEContainerSet : public juce::Component {
   int getNumContainers() { return containers_->size(); }
 
   int calculateContainerHeight() {
-    return getNumContainers() * (kMixContainerHeight_ + kMixContainerSpacing_);
+    int total = 0;
+    for (auto& pair : *containers_)
+      total += kMixContainerSpacing_ + pair.second->getPreferredHeight();
+    return total;
   }
 
   const int getViewPortMaxHeight() {
@@ -44,9 +47,10 @@ class AEContainerSet : public juce::Component {
   void paint(juce::Graphics& g) override {
     auto bounds = getLocalBounds();
     for (auto& pair : *containers_) {
-      bounds.removeFromTop(kMixContainerSpacing_);  // Add some padding
+      bounds.removeFromTop(kMixContainerSpacing_);
       addAndMakeVisible(pair.second.get());
-      pair.second.get()->setBounds(bounds.removeFromTop(kMixContainerHeight_));
+      pair.second.get()->setBounds(
+          bounds.removeFromTop(pair.second->getPreferredHeight()));
     }
   }
 

--- a/common/components/src/MixAEContainer.h
+++ b/common/components/src/MixAEContainer.h
@@ -17,14 +17,22 @@
 #pragma once
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "EclipsaColours.h"
-#include "Icons.h"
+#include "components/icons/svg/SvgIconComponent.h"
+#include "components/icons/svg/SvgIconLookup.h"
 
-class MixAEContainer : public juce::Component {
+class MixAEContainer : public juce::Component, public juce::Timer {
  public:
+  static constexpr int kCollapsedHeight = 36;
+  static constexpr int kExpandedHeight = 220;
+
   MixAEContainer(const juce::String& title, const juce::String& desc)
-      : name_(title), desc_(desc), isBinauralCheckbox_("Binaural") {
+      : name_(title),
+        desc_(desc),
+        binauralRadio_("Binaural (3D Spatial)"),
+        standardStereoRadio_("Standard Stereo") {
     nameLabel_.setText(name_, juce::dontSendNotification);
     nameLabel_.setColour(juce::Label::textColourId,
                          EclipsaColours::headingGrey);
@@ -34,91 +42,188 @@ class MixAEContainer : public juce::Component {
     descLabel_.setText(desc_, juce::dontSendNotification);
     descLabel_.setColour(juce::Label::textColourId,
                          EclipsaColours::tabTextGrey);
+    descLabel_.setFont(juce::Font(12.0f));
     descLabel_.setJustificationType(juce::Justification::topLeft);
     addAndMakeVisible(descLabel_);
 
-    juce::Image removeAEImage = IconStore::getInstance().getRemoveAEIcon();
-    removeAEButton_.setImages(true, true, true, removeAEImage, 1.0f,
-                              juce::Colours::transparentBlack, removeAEImage,
-                              0.5f, juce::Colours::grey, removeAEImage, 0.8f,
-                              EclipsaColours::iconWhite);
     addAndMakeVisible(removeAEButton_);
+    addAndMakeVisible(headphonesIcon_);
 
-    isBinauralCheckbox_.setColour(juce::ToggleButton::textColourId,
-                                  EclipsaColours::headingGrey);
-    addAndMakeVisible(isBinauralCheckbox_);
+    selectedOptionLabel_.setText("Standard Stereo", juce::dontSendNotification);
+    selectedOptionLabel_.setColour(juce::Label::textColourId,
+                                   EclipsaColours::headingGrey);
+    selectedOptionLabel_.setJustificationType(juce::Justification::centredLeft);
+    addAndMakeVisible(selectedOptionLabel_);
 
-    // Configure the tooltip image
-    tooltipImage_.setImage(IconStore::getInstance().getTooltipIcon());
-    tooltipImage_.setTooltip(
-        "Binaural\n\n"
-        "If checked, this audio element will be rendered binaurally during "
-        "binaural "
-        "playback. \n"
-        "If unchecked, this audio element will be rendered as stereo during "
-        "binaural playback.");
+    expandToggleButton_.onClick = [this]() { toggleExpand(); };
+    addAndMakeVisible(expandToggleButton_);
 
-    addAndMakeVisible(tooltipImage_);
+    nameLabel_.setInterceptsMouseClicks(false, false);
+    descLabel_.setInterceptsMouseClicks(false, false);
+    selectedOptionLabel_.setInterceptsMouseClicks(false, false);
+    headphonesIcon_.setInterceptsMouseClicks(false, false);
+
+    addChildComponent(headingRow_);
+
+    sectionSubtitleLabel_.setText(
+        "Defines how playback devices render this Audio Element on headphones.",
+        juce::dontSendNotification);
+    sectionSubtitleLabel_.setColour(juce::Label::textColourId,
+                                    EclipsaColours::tabTextGrey);
+    sectionSubtitleLabel_.setFont(juce::Font(13.0f));
+    sectionSubtitleLabel_.setJustificationType(
+        juce::Justification::centredLeft);
+    addChildComponent(sectionSubtitleLabel_);
+
+    binauralRadio_.setRadioGroupId(1);
+    binauralRadio_.setLookAndFeel(&radioLookAndFeel_);
+    addChildComponent(binauralRadio_);
+
+    addChildComponent(binauralDesc_);
+
+    standardStereoRadio_.setRadioGroupId(1);
+    standardStereoRadio_.setToggleState(true, juce::dontSendNotification);
+    standardStereoRadio_.setLookAndFeel(&radioLookAndFeel_);
+    addChildComponent(standardStereoRadio_);
+
+    addChildComponent(standardStereoDesc_);
   }
 
   ~MixAEContainer() override {
-    for (auto listener : listeners_) {
-      removeAEButton_.removeListener(listener);
-    }
+    stopTimer();
+    juce::Desktop::getInstance().removeGlobalMouseListener(
+        &globalMouseWatcher_);
+    for (auto listener : listeners_) removeAEButton_.removeListener(listener);
+    binauralRadio_.setLookAndFeel(nullptr);
+    standardStereoRadio_.setLookAndFeel(nullptr);
     setLookAndFeel(nullptr);
   }
+
   void setBinauralChangeHandler(std::function<void(bool)> callback) {
-    isBinauralCheckbox_.onClick = [callback, this]() {
-      callback(isBinauralCheckbox_.getToggleState());
+    binauralRadio_.onClick = [callback, this]() {
+      if (binauralRadio_.getToggleState()) {
+        selectedOptionLabel_.setText("Binaural", juce::dontSendNotification);
+        resized();
+        callback(true);
+      }
+    };
+    standardStereoRadio_.onClick = [callback, this]() {
+      if (standardStereoRadio_.getToggleState()) {
+        selectedOptionLabel_.setText("Standard Stereo",
+                                     juce::dontSendNotification);
+        resized();
+        callback(false);
+      }
     };
   }
-  void paint(juce::Graphics& g) override {
+
+  void setBinauralState(bool isBinaural) {
+    binauralRadio_.setToggleState(isBinaural, juce::dontSendNotification);
+    standardStereoRadio_.setToggleState(!isBinaural,
+                                        juce::dontSendNotification);
+    selectedOptionLabel_.setText(isBinaural ? "Binaural" : "Standard Stereo",
+                                 juce::dontSendNotification);
+  }
+
+  void setAudioElementConstraints(bool isBinauralElement,
+                                  bool isStereoElement) {
+    const bool locked = isBinauralElement;
+    const bool defaultBinaural = !isBinauralElement && !isStereoElement;
+    setBinauralState(defaultBinaural);
+    binauralRadio_.setEnabled(!locked);
+    standardStereoRadio_.setEnabled(!locked);
+  }
+
+  void setOnExpandStateChanged(std::function<void()> cb) {
+    onExpandStateChanged_ = std::move(cb);
+  }
+
+  int getPreferredHeight() const { return (int)std::round(animatedHeight_); }
+
+  void resized() override {
     auto bounds = getLocalBounds();
-    const auto mixAEContainerBounds = bounds;
 
-    // Set the background colour to grey
-    g.setColour(EclipsaColours::inactiveGrey);
+    // Header
+    auto headerBounds = bounds.removeFromTop(kCollapsedHeight);
+    const auto fullHeaderBounds = headerBounds;
 
-    // Draw a filled rounded rectangle
-    juce::Rectangle<float> rect(bounds.toFloat());
-    g.fillRect(rect);
-    const float labelWidth = 0.6f;
-    auto labelBounds = bounds.removeFromLeft(
-        mixAEContainerBounds.proportionOfWidth(labelWidth));
+    removeAEButton_.setBounds(headerBounds.removeFromLeft(36).reduced(8, 8));
 
-    auto nameBounds = labelBounds.removeFromTop(
-        mixAEContainerBounds.proportionOfHeight(0.5f));
-    nameLabel_.setBounds(nameBounds);
-    nameLabel_.setColour(juce::Label::textColourId,
-                         EclipsaColours::headingGrey);
+    auto labelBounds =
+        headerBounds.removeFromLeft(headerBounds.proportionOfWidth(0.5f));
+    labelBounds.removeFromTop(4);
+    nameLabel_.setBounds(
+        labelBounds.removeFromTop(labelBounds.getHeight() / 2));
+    labelBounds.removeFromTop(-2);
     descLabel_.setBounds(labelBounds);
-    descLabel_.setColour(juce::Label::textColourId,
-                         EclipsaColours::tabTextGrey);
 
-    int toRemove = 6;
-    bounds.reduce(toRemove, toRemove);
+    headerBounds.reduce(10, 10);
+    constexpr int kIconTextGap = 6;
+    expandToggleButton_.setBounds(headerBounds.removeFromRight(14));
+    headerBounds.removeFromRight(kIconTextGap);
+    juce::AttributedString as;
+    as.append(selectedOptionLabel_.getText(), selectedOptionLabel_.getFont(),
+              EclipsaColours::headingGrey);
+    juce::TextLayout tl;
+    tl.createLayout(as, 10000.0f);
+    const int textWidth = (int)std::ceil(tl.getWidth()) + 2;
+    selectedOptionLabel_.setBounds(headerBounds.removeFromRight(textWidth));
+    headerBounds.removeFromRight(kIconTextGap);
+    headphonesIcon_.setBounds(headerBounds.removeFromRight(20));
 
-    const float tooltipImageWidth = 0.04f;
-    const float binauralCheckboxWidth = 0.12f;
+    if (!isExpanded_) return;
 
-    auto tooltipImageBounds = bounds.removeFromRight(
-        mixAEContainerBounds.proportionOfWidth(tooltipImageWidth));
-    tooltipImage_.setBounds(tooltipImageBounds);
+    // Expanded panel
+    auto panelBounds = bounds;
+    panelBounds.removeFromLeft(12);
+    panelBounds.removeFromRight(12);
+    panelBounds.removeFromTop(12);
 
-    // Reserve space for the checkbox and button
-    auto checkboxBounds = bounds.removeFromRight(
-        mixAEContainerBounds.proportionOfWidth(binauralCheckboxWidth));
-    isBinauralCheckbox_.setBounds(checkboxBounds);
+    const int w = panelBounds.getWidth();
+    const int descWidth = w - 32;
 
-    auto buttonBounds = bounds;
-    removeAEButton_.setBounds(buttonBounds);
+    juce::FlexBox fb;
+    fb.flexDirection = juce::FlexBox::Direction::column;
+
+    fb.items.add(
+        juce::FlexItem(headingRow_).withWidth((float)w).withHeight(26.0f));
+    fb.items.add(juce::FlexItem(sectionSubtitleLabel_)
+                     .withWidth((float)w)
+                     .withHeight(22.0f)
+                     .withMargin({-5.0f, 0.0f, 10.0f, 0.0f}));
+    fb.items.add(
+        juce::FlexItem(binauralRadio_).withWidth((float)w).withHeight(26.0f));
+    fb.items.add(
+        juce::FlexItem(binauralDesc_)
+            .withWidth((float)descWidth)
+            .withHeight((float)binauralDesc_.getPreferredHeight(descWidth))
+            .withMargin({0.0f, 0.0f, 10.0f, 32.0f}));
+    fb.items.add(juce::FlexItem(standardStereoRadio_)
+                     .withWidth((float)w)
+                     .withHeight(26.0f));
+    fb.items.add(juce::FlexItem(standardStereoDesc_)
+                     .withWidth((float)descWidth)
+                     .withHeight((float)standardStereoDesc_.getPreferredHeight(
+                         descWidth))
+                     .withMargin({0.0f, 0.0f, 0.0f, 32.0f}));
+
+    fb.performLayout(panelBounds.toFloat());
   }
 
-  const juce::ImageButton* const getDeleteButton() const {
-    return &removeAEButton_;
+  void paint(juce::Graphics& g) override {
+    g.setColour(EclipsaColours::inactiveGrey);
+    g.fillRect(getLocalBounds().toFloat());
+
+    if (isExpanded_) {
+      g.setColour(EclipsaColours::gridLine);
+      g.fillRect(getLocalBounds()
+                     .removeFromTop(kCollapsedHeight + 1)
+                     .removeFromBottom(1)
+                     .toFloat());
+    }
   }
 
-  juce::ToggleButton* getIsBinauralCheckbox() { return &isBinauralCheckbox_; }
+  const juce::Button* const getDeleteButton() const { return &removeAEButton_; }
 
   void setDeleteButtonListener(juce::Button::Listener* listener) {
     removeAEButton_.addListener(listener);
@@ -132,16 +237,245 @@ class MixAEContainer : public juce::Component {
   }
 
  private:
+  class SvgButton : public juce::Button {
+   public:
+    SvgButton(SvgMap::Icon icon, bool hoverDarken = false)
+        : juce::Button(""), iconComponent_(icon), hoverDarken_(hoverDarken) {
+      addAndMakeVisible(iconComponent_);
+    }
+
+    void paintButton(juce::Graphics& g, bool shouldDrawButtonAsHighlighted,
+                     bool /*shouldDrawButtonAsDown*/) override {
+      if (hoverDarken_ && shouldDrawButtonAsHighlighted) {
+        g.setColour(juce::Colours::black.withAlpha(0.25f));
+        g.fillEllipse(getLocalBounds().toFloat());
+      }
+    }
+
+    void resized() override { iconComponent_.setBounds(getLocalBounds()); }
+
+   private:
+    SvgIconComponent iconComponent_;
+    bool hoverDarken_ = false;
+  };
+
+  class SVGToolTip : public juce::Component,
+                     public juce::SettableTooltipClient {
+   public:
+    SVGToolTip(SvgMap::Icon icon, const juce::String& tooltipText)
+        : iconComponent_(icon) {
+      setTooltip(tooltipText);
+      addAndMakeVisible(iconComponent_);
+    }
+
+    void resized() override {
+      int sz = juce::jmin(getWidth(), getHeight());
+      iconComponent_.setBounds(juce::Rectangle<int>(sz, sz).withCentre(
+          getLocalBounds().getCentre()));
+    }
+
+   private:
+    SvgIconComponent iconComponent_;
+  };
+
+  class RadioLookAndFeel : public juce::LookAndFeel_V4 {
+   public:
+    void drawToggleButton(juce::Graphics& g, juce::ToggleButton& button,
+                          bool /*shouldDrawButtonAsHighlighted*/,
+                          bool /*shouldDrawButtonAsDown*/) override {
+      const float alpha = button.isEnabled() ? 1.0f : 0.35f;
+      const float circleSize = 20.0f;
+      const float cx = 2.0f;
+      const float cy = (button.getHeight() - circleSize) * 0.5f;
+
+      if (button.getToggleState()) {
+        g.setColour(EclipsaColours::selectCyan.withAlpha(alpha));
+        g.drawEllipse(cx, cy, circleSize, circleSize, 2.0f);
+        const float innerSize = circleSize * 0.6f;
+        g.fillEllipse(cx + (circleSize - innerSize) * 0.5f,
+                      cy + (circleSize - innerSize) * 0.5f, innerSize,
+                      innerSize);
+      } else {
+        g.setColour(EclipsaColours::selectionToggleBorderGrey.withAlpha(alpha));
+        g.drawEllipse(cx, cy, circleSize, circleSize, 1.5f);
+      }
+
+      const float textX = cx + circleSize + 10.0f;
+      g.setColour(EclipsaColours::headingGrey.withAlpha(alpha));
+      g.setFont(juce::Font(15.0f, juce::Font::bold));
+      g.drawText(button.getButtonText(),
+                 juce::Rectangle<float>(textX, 0.0f, button.getWidth() - textX,
+                                        static_cast<float>(button.getHeight())),
+                 juce::Justification::centredLeft);
+    }
+  };
+
+  class MultilineText : public juce::Component {
+   public:
+    MultilineText(const juce::String& text, float fontSize, juce::Colour colour)
+        : text_(text), font_(fontSize), colour_(colour) {}
+
+    int getPreferredHeight(int width) const {
+      if (width <= 0) return 0;
+      juce::AttributedString as;
+      as.append(text_, font_, colour_);
+      as.setWordWrap(juce::AttributedString::byWord);
+      juce::TextLayout tl;
+      tl.createLayout(as, (float)width);
+      return (int)std::ceil(tl.getHeight());
+    }
+
+    void paint(juce::Graphics& g) override {
+      juce::AttributedString as;
+      as.append(text_, font_, colour_);
+      as.setWordWrap(juce::AttributedString::byWord);
+      juce::TextLayout tl;
+      tl.createLayout(as, (float)getWidth());
+      tl.draw(g, getLocalBounds().toFloat());
+    }
+
+   private:
+    juce::String text_;
+    juce::Font font_;
+    juce::Colour colour_;
+  };
+
+  class HeadingRow : public juce::Component {
+   public:
+    HeadingRow() {
+      titleLabel_.setText("Headphone Spatialization",
+                          juce::dontSendNotification);
+      titleLabel_.setColour(juce::Label::textColourId,
+                            EclipsaColours::headingGrey);
+      titleLabel_.setFont(juce::Font(16.0f, juce::Font::bold));
+      addAndMakeVisible(icon_);
+      addAndMakeVisible(titleLabel_);
+      addAndMakeVisible(helpIcon_);
+    }
+
+    void resized() override {
+      const float iconSize = 14.0f;
+      const float iconGap = 4.0f;
+      const float tooltipGap = 4.0f;
+      const float tooltipSize = 14.0f;
+
+      juce::FlexBox fb;
+      fb.flexDirection = juce::FlexBox::Direction::row;
+      fb.alignItems = juce::FlexBox::AlignItems::center;
+
+      fb.items.add(juce::FlexItem(icon_)
+                       .withWidth(iconSize)
+                       .withHeight(iconSize)
+                       .withMargin({0.0f, iconGap, 0.0f, 0.0f}));
+      const float titleWidth =
+          titleLabel_.getFont().getStringWidthFloat(titleLabel_.getText());
+      fb.items.add(juce::FlexItem(titleLabel_)
+                       .withWidth(titleWidth)
+                       .withHeight((float)getHeight()));
+      fb.items.add(juce::FlexItem(helpIcon_)
+                       .withWidth(tooltipSize)
+                       .withHeight(tooltipSize)
+                       .withMargin({0.0f, 0.0f, 0.0f, tooltipGap}));
+
+      fb.performLayout(getLocalBounds().toFloat());
+    }
+
+   private:
+    SvgIconComponent icon_{SvgMap::kHeadphones};
+    juce::Label titleLabel_;
+    SvgIconComponent helpIcon_{SvgMap::kHelp};
+  };
+
+  void mouseDown(const juce::MouseEvent&) override {
+    if (getMouseXYRelative().getY() >= kCollapsedHeight) return;
+    toggleExpand();
+  }
+
+  void toggleExpand() { setExpanded(!isExpanded_); }
+
+  void setExpanded(bool expanded) {
+    if (isExpanded_ == expanded) return;
+    isExpanded_ = expanded;
+    if (isExpanded_) {
+      updateExpandedVisibility();
+      juce::Desktop::getInstance().addGlobalMouseListener(&globalMouseWatcher_);
+    }
+    startTimerHz(360);
+  }
+
+  void timerCallback() override {
+    const float target =
+        isExpanded_ ? (float)kExpandedHeight : (float)kCollapsedHeight;
+    animatedHeight_ += (target - animatedHeight_) * 0.25f;
+
+    if (std::abs(animatedHeight_ - target) < 0.5f) {
+      animatedHeight_ = target;
+      stopTimer();
+      if (!isExpanded_) {
+        updateExpandedVisibility();
+        juce::Desktop::getInstance().removeGlobalMouseListener(
+            &globalMouseWatcher_);
+      }
+    }
+
+    if (onExpandStateChanged_) onExpandStateChanged_();
+    resized();
+    repaint();
+  }
+
+  void updateExpandedVisibility() {
+    headingRow_.setVisible(isExpanded_);
+    sectionSubtitleLabel_.setVisible(isExpanded_);
+    binauralRadio_.setVisible(isExpanded_);
+    binauralDesc_.setVisible(isExpanded_);
+    standardStereoRadio_.setVisible(isExpanded_);
+    standardStereoDesc_.setVisible(isExpanded_);
+  }
+
   juce::String name_;
   juce::String desc_;
+  bool isExpanded_ = false;
+  float animatedHeight_ = (float)kCollapsedHeight;
 
   juce::Label nameLabel_;
   juce::Label descLabel_;
 
-  juce::ImageButton removeAEButton_;
-  juce::ToggleButton isBinauralCheckbox_;
-  juce::TooltipWindow tooltipWindow_;
-  juce::ImageComponent tooltipImage_;
+  SvgButton removeAEButton_{SvgMap::kRemoveAE, true};
+  SvgIconComponent headphonesIcon_{SvgMap::kHeadphones};
+  juce::Label selectedOptionLabel_;
+  SvgButton expandToggleButton_{SvgMap::kDropdownArrow};
 
+  HeadingRow headingRow_;
+  juce::TooltipWindow tooltipWindow_{this};
+  juce::Label sectionSubtitleLabel_;
+
+  RadioLookAndFeel radioLookAndFeel_;
+  juce::ToggleButton binauralRadio_;
+  MultilineText binauralDesc_{
+      "Uses virtualization during playback on headphones to create an "
+      "externalized 3D soundstage outside the listener's head.",
+      12.0f, EclipsaColours::tabTextGrey};
+  juce::ToggleButton standardStereoRadio_;
+  MultilineText standardStereoDesc_{
+      "Uses standard stereo fold-down without virtualization. Stereo and "
+      "pre-rendered binaural Audio Elements are directly passed through.",
+      12.0f, EclipsaColours::tabTextGrey};
+
+  class GlobalMouseWatcher : public juce::MouseListener {
+   public:
+    explicit GlobalMouseWatcher(MixAEContainer& owner) : owner_(owner) {}
+    void mouseDown(const juce::MouseEvent& e) override {
+      auto screenBounds = owner_.localAreaToGlobal(owner_.getLocalBounds());
+      if (!screenBounds.contains(e.getScreenPosition())) {
+        owner_.setExpanded(false);
+      }
+    }
+
+   private:
+    MixAEContainer& owner_;
+  };
+
+  std::function<void()> onExpandStateChanged_;
   std::vector<juce::Button::Listener*> listeners_;
+  GlobalMouseWatcher globalMouseWatcher_{*this};
 };

--- a/common/components/src/MixAEContainer.h
+++ b/common/components/src/MixAEContainer.h
@@ -166,7 +166,7 @@ class MixAEContainer : public juce::Component, public juce::Timer {
               EclipsaColours::headingGrey);
     juce::TextLayout tl;
     tl.createLayout(as, 10000.0f);
-    const int textWidth = (int)std::ceil(tl.getWidth()) + 2;
+    const int textWidth = (int)std::ceil(tl.getWidth()) + 8;
     selectedOptionLabel_.setBounds(headerBounds.removeFromRight(textWidth));
     headerBounds.removeFromRight(kIconTextGap);
     headphonesIcon_.setBounds(headerBounds.removeFromRight(20));

--- a/common/components/src/MixAEContainer.h
+++ b/common/components/src/MixAEContainer.h
@@ -27,6 +27,7 @@ class MixAEContainer : public juce::Component, public juce::Timer {
  public:
   static constexpr int kCollapsedHeight = 36;
   static constexpr int kExpandedHeight = 220;
+  static constexpr int kBinauralLockedExpandedHeight = 100;
 
   MixAEContainer(const juce::String& title, const juce::String& desc)
       : name_(title),
@@ -87,6 +88,8 @@ class MixAEContainer : public juce::Component, public juce::Timer {
     addChildComponent(standardStereoRadio_);
 
     addChildComponent(standardStereoDesc_);
+
+    addChildComponent(binauralLockedMessage_);
   }
 
   ~MixAEContainer() override {
@@ -127,11 +130,13 @@ class MixAEContainer : public juce::Component, public juce::Timer {
 
   void setAudioElementConstraints(bool isBinauralElement,
                                   bool isStereoElement) {
-    const bool locked = isBinauralElement;
+    isBinauralLocked_ = isBinauralElement;
     const bool defaultBinaural = !isBinauralElement && !isStereoElement;
     setBinauralState(defaultBinaural);
-    binauralRadio_.setEnabled(!locked);
-    standardStereoRadio_.setEnabled(!locked);
+    binauralRadio_.setEnabled(true);
+    standardStereoRadio_.setEnabled(true);
+    updateExpandedVisibility();
+    resized();
   }
 
   void setOnExpandStateChanged(std::function<void()> cb) {
@@ -187,25 +192,35 @@ class MixAEContainer : public juce::Component, public juce::Timer {
 
     fb.items.add(
         juce::FlexItem(headingRow_).withWidth((float)w).withHeight(26.0f));
-    fb.items.add(juce::FlexItem(sectionSubtitleLabel_)
-                     .withWidth((float)w)
-                     .withHeight(22.0f)
-                     .withMargin({-5.0f, 0.0f, 10.0f, -6.0f}));
-    fb.items.add(
-        juce::FlexItem(binauralRadio_).withWidth((float)w).withHeight(26.0f));
-    fb.items.add(
-        juce::FlexItem(binauralDesc_)
-            .withWidth((float)descWidth)
-            .withHeight((float)binauralDesc_.getPreferredHeight(descWidth))
-            .withMargin({0.0f, 0.0f, 10.0f, 32.0f}));
-    fb.items.add(juce::FlexItem(standardStereoRadio_)
-                     .withWidth((float)w)
-                     .withHeight(26.0f));
-    fb.items.add(juce::FlexItem(standardStereoDesc_)
-                     .withWidth((float)descWidth)
-                     .withHeight((float)standardStereoDesc_.getPreferredHeight(
-                         descWidth))
-                     .withMargin({0.0f, 0.0f, 0.0f, 32.0f}));
+
+    if (isBinauralLocked_) {
+      fb.items.add(
+          juce::FlexItem(binauralLockedMessage_)
+              .withWidth((float)w)
+              .withHeight((float)binauralLockedMessage_.getPreferredHeight(w))
+              .withMargin({0.0f, 0.0f, 0.0f, 0.0f}));
+    } else {
+      fb.items.add(juce::FlexItem(sectionSubtitleLabel_)
+                       .withWidth((float)w)
+                       .withHeight(22.0f)
+                       .withMargin({-5.0f, 0.0f, 10.0f, -6.0f}));
+      fb.items.add(
+          juce::FlexItem(binauralRadio_).withWidth((float)w).withHeight(26.0f));
+      fb.items.add(
+          juce::FlexItem(binauralDesc_)
+              .withWidth((float)descWidth)
+              .withHeight((float)binauralDesc_.getPreferredHeight(descWidth))
+              .withMargin({0.0f, 0.0f, 10.0f, 32.0f}));
+      fb.items.add(juce::FlexItem(standardStereoRadio_)
+                       .withWidth((float)w)
+                       .withHeight(26.0f));
+      fb.items.add(
+          juce::FlexItem(standardStereoDesc_)
+              .withWidth((float)descWidth)
+              .withHeight(
+                  (float)standardStereoDesc_.getPreferredHeight(descWidth))
+              .withMargin({0.0f, 0.0f, 0.0f, 32.0f}));
+    }
 
     fb.performLayout(panelBounds.toFloat());
   }
@@ -404,8 +419,10 @@ class MixAEContainer : public juce::Component, public juce::Timer {
   }
 
   void timerCallback() override {
+    const int expandedTarget =
+        isBinauralLocked_ ? kBinauralLockedExpandedHeight : kExpandedHeight;
     const float target =
-        isExpanded_ ? (float)kExpandedHeight : (float)kCollapsedHeight;
+        isExpanded_ ? (float)expandedTarget : (float)kCollapsedHeight;
     animatedHeight_ += (target - animatedHeight_) * 0.25f;
 
     if (std::abs(animatedHeight_ - target) < 0.5f) {
@@ -424,12 +441,15 @@ class MixAEContainer : public juce::Component, public juce::Timer {
   }
 
   void updateExpandedVisibility() {
+    const bool showRadios = isExpanded_ && !isBinauralLocked_;
+    const bool showLockedMessage = isExpanded_ && isBinauralLocked_;
     headingRow_.setVisible(isExpanded_);
-    sectionSubtitleLabel_.setVisible(isExpanded_);
-    binauralRadio_.setVisible(isExpanded_);
-    binauralDesc_.setVisible(isExpanded_);
-    standardStereoRadio_.setVisible(isExpanded_);
-    standardStereoDesc_.setVisible(isExpanded_);
+    sectionSubtitleLabel_.setVisible(showRadios);
+    binauralRadio_.setVisible(showRadios);
+    binauralDesc_.setVisible(showRadios);
+    standardStereoRadio_.setVisible(showRadios);
+    standardStereoDesc_.setVisible(showRadios);
+    binauralLockedMessage_.setVisible(showLockedMessage);
   }
 
   juce::String name_;
@@ -460,6 +480,12 @@ class MixAEContainer : public juce::Component, public juce::Timer {
       "Uses standard stereo fold-down without virtualization. Stereo and "
       "pre-rendered binaural Audio Elements are directly passed through.",
       12.0f, EclipsaColours::tabTextGrey};
+
+  bool isBinauralLocked_ = false;
+  MultilineText binauralLockedMessage_{
+      "This Audio Element is already spatially rendered. Audio is directly "
+      "passed through.",
+      13.0f, EclipsaColours::tabTextGrey};
 
   class GlobalMouseWatcher : public juce::MouseListener {
    public:

--- a/common/components/src/MixAEContainer.h
+++ b/common/components/src/MixAEContainer.h
@@ -27,7 +27,7 @@ class MixAEContainer : public juce::Component, public juce::Timer {
  public:
   static constexpr int kCollapsedHeight = 36;
   static constexpr int kExpandedHeight = 220;
-  static constexpr int kBinauralLockedExpandedHeight = 100;
+  static constexpr int kBinauralLockedExpandedHeight = 120;
 
   MixAEContainer(const juce::String& title, const juce::String& desc)
       : name_(title),
@@ -483,8 +483,8 @@ class MixAEContainer : public juce::Component, public juce::Timer {
 
   bool isBinauralLocked_ = false;
   MultilineText binauralLockedMessage_{
-      "This Audio Element is already spatially rendered. Audio is directly "
-      "passed through.",
+      "This Audio Element has already been spatially rendered. The audio will "
+      "be passed through without additional spatial processing.",
       13.0f, EclipsaColours::tabTextGrey};
 
   class GlobalMouseWatcher : public juce::MouseListener {

--- a/common/components/src/MixAEContainer.h
+++ b/common/components/src/MixAEContainer.h
@@ -190,7 +190,7 @@ class MixAEContainer : public juce::Component, public juce::Timer {
     fb.items.add(juce::FlexItem(sectionSubtitleLabel_)
                      .withWidth((float)w)
                      .withHeight(22.0f)
-                     .withMargin({-5.0f, 0.0f, 10.0f, 0.0f}));
+                     .withMargin({-5.0f, 0.0f, 10.0f, -6.0f}));
     fb.items.add(
         juce::FlexItem(binauralRadio_).withWidth((float)w).withHeight(26.0f));
     fb.items.add(

--- a/rendererplugin/src/screens/mix_tabs/PresentationEditorTab.cpp
+++ b/rendererplugin/src/screens/mix_tabs/PresentationEditorTab.cpp
@@ -326,9 +326,9 @@ void PresentationEditorTab::getAudioElements() {
               audioElement->getChannelConfig().toString());
       auto container = audioElementsAlreadyDrawn_[audioElementId].get();
       container->setDeleteButtonListener(this);
-      // Set checkbox state from repository
-      container->getIsBinauralCheckbox()->setToggleState(
-          mixAE.isBinaural(), juce::dontSendNotification);
+      container->setAudioElementConstraints(
+          audioElement->getChannelConfig() == Speakers::kBinaural,
+          audioElement->getChannelConfig() == Speakers::kStereo);
       // Set change handler to update repository
       container->setBinauralChangeHandler(
           [this, audioElementId](bool newBinauralState) {
@@ -428,12 +428,16 @@ void PresentationEditorTab::addToAlreadyDrawnMap(
   audioElementsAlreadyDrawn_[audioElementId] =
       std::make_unique<MixAEContainer>(mixAE.getName(), channelConfigStr);
   audioElementsAlreadyDrawn_[audioElementId]->setDeleteButtonListener(this);
-
-  // Set up the isBinaural checkbox
-  auto isBinauralCheckbox =
-      audioElementsAlreadyDrawn_[audioElementId]->getIsBinauralCheckbox();
-  isBinauralCheckbox->setToggleState(mixAE.isBinaural(),
-                                     juce::dontSendNotification);
+  if (linkedAudioElementOpt.has_value()) {
+    audioElementsAlreadyDrawn_[audioElementId]->setAudioElementConstraints(
+        linkedAudioElementOpt->getChannelConfig() == Speakers::kBinaural,
+        linkedAudioElementOpt->getChannelConfig() == Speakers::kStereo);
+  } else {
+    audioElementsAlreadyDrawn_[audioElementId]->setBinauralState(
+        mixAE.isBinaural());
+  }
+  audioElementsAlreadyDrawn_[audioElementId]->setOnExpandStateChanged(
+      [this]() { viewPort_.repaint(); });
 
   audioElementsAlreadyDrawn_[audioElementId]->setBinauralChangeHandler(
       [this, audioElementId](bool newBinauralState) {

--- a/rendererplugin/src/screens/mix_tabs/PresentationEditorViewPort.cpp
+++ b/rendererplugin/src/screens/mix_tabs/PresentationEditorViewPort.cpp
@@ -30,9 +30,6 @@ PresentationEditorViewPort::PresentationEditorViewPort(
 void PresentationEditorViewPort::paint(juce::Graphics& g) {
   const auto bounds = getLocalBounds();
   viewPort_.setSize(bounds.getWidth(), bounds.getHeight());
-  if (set_.getNumContainers() <= set_.kMaxContainerThreshold) {
-    set_.setSize(bounds.getWidth(), bounds.getHeight());
-  } else {
-    set_.setSize(bounds.getWidth(), set_.calculateContainerHeight());
-  }
+  set_.setSize(bounds.getWidth(),
+               std::max(bounds.getHeight(), set_.calculateContainerHeight()));
 }


### PR DESCRIPTION
### Description

Update tooltip and dropdown for binaural rendering options. Implements [this ref](https://github.com/WithACX/groove/issues/635#issuecomment-4614965873).

### Changes

1. Added a tooltip dropdown for each element explaining rendering options.


https://github.com/user-attachments/assets/2a70de10-f8ee-4ba0-ba28-b611c6cdbebf





### Validation and Acceptance Criteria

- [x] Tooltip render correctly with new text in UI.


