### PR TITLE
fix(export): default WAV per-element export checkbox to unchecked

### DIFF
--- a/common/data_structures/src/FileExport.cpp
+++ b/common/data_structures/src/FileExport.cpp
@@ -26,7 +26,7 @@ FileExport::FileExport()
       audioCodec_(LPCM),
       bitDepth_(16),
       sampleRate_(16000),
-      exportAudioElements_(true),
+      exportAudioElements_(false),
       exportAudio_(false),
       exportVideo_(false),
       videoSource_(""),

--- a/common/data_structures/tests/CMakeLists.txt
+++ b/common/data_structures/tests/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 eclipsa_add_test(test_audio_element AudioElement_test.cpp "data_structures")
+eclipsa_add_test(test_file_export FileExport_test.cpp "data_structures")
 eclipsa_add_test(test_room_setup RoomSetup_test.cpp "data_structures")
 eclipsa_add_test(test_mix_presentation MixPresentation_test.cpp "data_structures")
 eclipsa_add_test(test_channel_gains ChannelGains_test.cpp "data_structures")

--- a/common/data_structures/tests/FileExport_test.cpp
+++ b/common/data_structures/tests/FileExport_test.cpp
@@ -1,0 +1,36 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/FileExport.h"
+
+#include <gtest/gtest.h>
+#include <juce_data_structures/juce_data_structures.h>
+
+TEST(test_file_export, default_state) {
+  const FileExport fileExport;
+
+  // Per-element WAV export is opt-in: a fresh export screen (default
+  // FileExport state) must not have it enabled.
+  EXPECT_FALSE(fileExport.getExportAudioElements());
+}
+
+TEST(test_file_export, from_tree_missing_export_audio_elements_defaults_false) {
+  // A ValueTree that never had kExportAudioElements set (e.g. an older
+  // saved session) must not implicitly re-enable per-element WAV export.
+  const juce::ValueTree tree{FileExport::kTreeType, {}};
+
+  const FileExport fileExport = FileExport::fromTree(tree);
+
+  EXPECT_FALSE(fileExport.getExportAudioElements());
+}


### PR DESCRIPTION
FileExport's default constructor set exportAudioElements_ to true, so a fresh export screen showed the "Export audio elements as WAV" checkbox checked by default. Per-element WAV output is opt-in now: default constructor changed to exportAudioElements_(false). The feature itself is unchanged -- users can still enable it explicitly via the checkbox.

Added a test covering the default-constructor state and the fromTree case where the property is absent from the ValueTree (both resolve to false).