### PR TITLE
fix(ui): show "No file selected" instead of error before file is chosen

### DIFF
--- a/common/components/src/AudioFilePlayer.cpp
+++ b/common/components/src/AudioFilePlayer.cpp
@@ -266,6 +266,21 @@ void AudioFilePlayer::updateComponentVisibility() {
       (playState == FilePlayback::ProcessorState::kBuffering);
   const bool kError = (playState == FilePlayback::ProcessorState::kError);
   fileSelectLabel_.setVisible(kError);
+  if (kError) {
+    // kError is also the zero-initialized default state before any file has
+    // ever been loaded, so distinguish "nothing selected yet" (neutral) from
+    // a file that was set but failed to load (red error).
+    if (fpbr_.get().getPlaybackFile().isEmpty()) {
+      fileSelectLabel_.setText("No file selected", juce::dontSendNotification);
+      fileSelectLabel_.setColour(juce::Label::textColourId,
+                                 EclipsaColours::headingGrey);
+    } else {
+      fileSelectLabel_.setText("Invalid IAMF file selected for playback",
+                               juce::dontSendNotification);
+      fileSelectLabel_.setColour(juce::Label::textColourId,
+                                 EclipsaColours::red);
+    }
+  }
   playButton_.setVisible(!kPlaying && !kBuffering && !kError);
   pauseButton_.setVisible(kPlaying && !kError);
   stopButton_.setVisible(!kBuffering && !kError);


### PR DESCRIPTION
## What changed
`AudioFilePlayer::updateComponentVisibility()` (`common/components/src/AudioFilePlayer.cpp`) now distinguishes "no file selected yet" from "a file is set but genuinely invalid" in the renderer's export validation screen. `FilePlayback::ProcessorState::kError` is enum value `0`, so it is also the zero-initialized default state before any file is ever loaded -- both cases previously rendered the same red `"Invalid IAMF file selected for playback"` label. The fix branches on `fpbr_.get().getPlaybackFile().isEmpty()`: empty shows a neutral `"No file selected"` in `EclipsaColours::headingGrey`; a set-but-failing file keeps the original red message. No changes to the state machine, visibility gating, or layout.

## Why
The issue names `common/components/src/ExportValidation.h`, but that file (`ExportValidationComponent`) has no validation-message logic of its own -- it owns an `AudioFilePlayer` sub-component, and that is where the label text/color actually live.

## Tests
No automated test added -- there is no existing test scaffold for this UI component. Manually verified in a Debug Standalone build: no file selected -> label reads "No file selected" (neutral); invalid file selected -> label reads "Invalid IAMF file selected for playback" (red); valid file selected -> normal playback controls show.

## Security notes
None. Presentation-only change (label text/color), no new inputs, no auth/secrets/permission paths touched.