### PR TITLE
fix(export): surface per-audio-element WAV writer failures

### DIFF
--- a/common/processors/file_output/AudioElementFileWriter.h
+++ b/common/processors/file_output/AudioElementFileWriter.h
@@ -49,9 +49,16 @@ class AudioElementFileWriter {
   AudioElementFileWriter& operator=(AudioElementFileWriter&&) noexcept =
       default;
 
-  void write(juce::AudioBuffer<float>& buffer) { fileWriter->write(buffer); }
+  // Returns whether the underlying file was successfully opened for writing.
+  bool isOpen() const { return fileWriter != nullptr && fileWriter->isOpen(); }
 
-  void close() { fileWriter->close(); }
+  // Returns false on a write failure (disk full, WAV size limit, etc.).
+  bool write(juce::AudioBuffer<float>& buffer) {
+    return fileWriter->write(buffer);
+  }
+
+  // Returns false if the writer opened but failed to flush/close cleanly.
+  bool close() { return fileWriter->close(); }
 
   AudioElement& getElement() { return element_; }
 

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -16,58 +16,21 @@
 
 #include <logger/logger.h>
 
-#include <cerrno>
-#include <filesystem>
-#include <fstream>
 #include <string>
 
+#include "WriteFailureClassifier.h"
 #include "data_repository/implementation/FilePlaybackRepository.h"
 #include "data_structures/src/AudioElement.h"
 #include "data_structures/src/FileExport.h"
 #include "data_structures/src/FilePlayback.h"
 #include "iamf_export_utils/IAMFExportUtil.h"
 
-// The probe filename is unique per call (rather than a fixed name) so a
-// symlink cannot be pre-planted at a predictable path in a shared/multi-user
-// export destination, and so two concurrent exports to the same folder
-// cannot collide on the same probe file.
+// Delegates to the shared classifier (WriteFailureClassifier.h) so every
+// writer path (IAMF, per-audio-element WAV, direct WAV export) classifies
+// failures the same way. Kept as a member for existing callers/tests.
 ExportError FileOutputProcessor::classifyWriteFailure(
     const juce::String& path) {
-  try {
-    const std::filesystem::path kParentDir =
-        std::filesystem::path(path.toStdString()).parent_path();
-    if (kParentDir.empty()) {
-      // No parent directory to probe -- don't fall back to probing the
-      // process's current working directory.
-      return kFileWriteFailed;
-    }
-    const std::filesystem::path kProbePath =
-        kParentDir /
-        (".acx_write_probe_" + juce::Uuid().toString().toStdString() + ".tmp");
-    std::ofstream probe(kProbePath);
-    if (!probe.is_open()) {
-      const int kProbeErrno = errno;
-      if (kProbeErrno == EACCES || kProbeErrno == EPERM ||
-          kProbeErrno == EROFS) {
-        return kPermissionDenied;
-      }
-      return kFileWriteFailed;
-    }
-    probe.close();
-    std::error_code removeEc;
-    std::filesystem::remove(kProbePath, removeEc);
-    if (removeEc) {
-      LOG_WARNING(0,
-                  "FileOutputProcessor: Failed to remove write-probe file: " +
-                      removeEc.message());
-    }
-    // The probe succeeded, so the parent directory is actually writable --
-    // the real failure must be something else (e.g. disk full, invalid
-    // filename).
-    return kFileWriteFailed;
-  } catch (const std::filesystem::filesystem_error&) {
-    return kFileWriteFailed;
-  }
+  return ::classifyWriteFailure(path);
 }
 
 //==============================================================================
@@ -144,7 +107,16 @@ void FileOutputProcessor::processBlock(juce::AudioBuffer<float>& buffer,
 
   // Process audio elements individually as Wav files
   for (int i = 0; i < iamfWavFileWriters_.size(); ++i) {
-    iamfWavFileWriters_[i]->write(buffer);
+    if (!iamfWavFileWriters_[i]->write(buffer)) {
+      // A per-audio-element frame write failed mid-export (e.g. disk full,
+      // WAV size limit exceeded). Record it unless a more specific error is
+      // already on record, mirroring the guard used for the IAMF path below.
+      FileExport config = fileExportRepository_.get();
+      if (config.getExportError() == kNoError) {
+        config.setExportError(kFileWriteFailed);
+        fileExportRepository_.update(config);
+      }
+    }
   }
 
   // Process IAMF File
@@ -225,13 +197,42 @@ void FileOutputProcessor::initializeFileExport(FileExport& config) {
     config.setExportError(kInvalidExportPath);
     fileExportRepository_.update(config);
   }
+
+  // Check the per-audio-element WAV writers for open failures (invalid or
+  // oversized element-name-derived filename, permission denied, disk full).
+  // Runs after the IAMF checks above so an IAMF-path error always wins --
+  // the guard below only ever records the first error of the export.
+  for (const auto& writer : iamfWavFileWriters_) {
+    if (!writer->isOpen()) {
+      LOG_ERROR(0,
+                "FileOutputProcessor: Failed to open per-audio-element WAV "
+                "file for writing: " +
+                    writer->getFilePath());
+      FileExport freshConfig = fileExportRepository_.get();
+      if (freshConfig.getExportError() == kNoError) {
+        freshConfig.setExportError(
+            classifyWriteFailure(juce::String(writer->getFilePath())));
+        fileExportRepository_.update(freshConfig);
+      }
+    }
+  }
 }
 
 void FileOutputProcessor::closeFileExport(const FileExport& config) {
   LOG_ANALYTICS(0, "closing writers and exporting IAMF file");
   // close the output file, since rendering is completed
   for (const auto& writer : iamfWavFileWriters_) {
-    writer->close();
+    if (!writer->close()) {
+      // The writer was opened successfully but failed to close/flush -- an
+      // unreported write failure. Only escalate if nothing more specific has
+      // already been recorded earlier in this export (mirrors the IAMF close
+      // guard just below).
+      FileExport freshConfig = fileExportRepository_.get();
+      if (freshConfig.getExportError() == kNoError) {
+        freshConfig.setExportError(kFileWriteFailed);
+        fileExportRepository_.update(freshConfig);
+      }
+    }
   }
 
   // If muxing is enabled and audio export was successful, mux the audio and

--- a/common/processors/file_output/FileOutputProcessor_PremierePro.cpp
+++ b/common/processors/file_output/FileOutputProcessor_PremierePro.cpp
@@ -88,7 +88,17 @@ void PremiereProFileOutputProcessor::processBlock(
 
   //  Write the audio data to the wav file writers
   for (auto& writer : iamfWavFileWriters_) {
-    writer->write(buffer);
+    if (!writer->write(buffer)) {
+      // A per-audio-element frame write failed mid-export (e.g. disk full).
+      // Record it unless a more specific error is already on record,
+      // mirroring the guard used for the IAMF path below and in the base
+      // FileOutputProcessor::processBlock.
+      FileExport config = fileExportRepository_.get();
+      if (config.getExportError() == kNoError) {
+        config.setExportError(kFileWriteFailed);
+        fileExportRepository_.update(config);
+      }
+    }
   }
 
   if (iamfFileWriter_ && !iamfFileWriter_->writeFrame(buffer)) {

--- a/common/processors/file_output/FileWriter.h
+++ b/common/processors/file_output/FileWriter.h
@@ -60,14 +60,18 @@ class FileWriter {
     }
   }
 
-  ~FileWriter() { close(); };
+  // Virtual so tests can subclass and override write()/close() to simulate
+  // a failure after a successful open (disk full, WAV 4GB cap) -- a
+  // FileWriter constructed against a real, writable path always opens
+  // successfully, so that scenario can't otherwise be reproduced in a test.
+  virtual ~FileWriter() { close(); };
 
   // Returns whether the underlying file was successfully opened for writing.
-  bool isOpen() const { return writer_ != nullptr; }
+  virtual bool isOpen() const { return writer_ != nullptr; }
 
   // Returns false (and writes nothing) if the writer failed to open, or if
   // the write itself fails (e.g. disk full, WAV 4GB size limit exceeded).
-  bool write(juce::AudioBuffer<float>& buffer) {
+  virtual bool write(juce::AudioBuffer<float>& buffer) {
     if (writer_ == nullptr) {
       return false;
     }
@@ -87,7 +91,7 @@ class FileWriter {
   // the underlying stream reports no error. A failure purely in the final
   // header rewrite (which JUCE performs in the writer's destructor with no
   // status return) cannot be detected here -- this is a best-effort check.
-  bool close() {
+  virtual bool close() {
     if (writer_ == nullptr) {
       return true;
     }

--- a/common/processors/file_output/FileWriter.h
+++ b/common/processors/file_output/FileWriter.h
@@ -24,39 +24,80 @@ class FileWriter {
  public:
   FileWriter(const juce::String& filename, double sampleRate, int numChannels,
              int firstChannel, int bitDepth, AudioCodec codec)
-      : numChannels_(numChannels),
+      : outputFile_(filename),
+        framesWritten(0),
+        numChannels_(numChannels),
         firstChannel_(firstChannel),
-        outputFile_(filename),
         bitDepth_(bitDepth) {
     outputFile_.deleteFile();
     juce::WavAudioFormat format;
-    writer_ = format.createWriterFor(new juce::FileOutputStream(outputFile_),
+    auto* stream = new juce::FileOutputStream(outputFile_);
+    writer_ = format.createWriterFor(stream,
                                      sampleRate,    // Sample Rate
                                      numChannels_,  // Number of channels
                                      bitDepth_,     // Bits per sample
                                      {},
                                      0  // Quality option index
     );
+    if (writer_ == nullptr) {
+      // createWriterFor does NOT take ownership of the stream when it fails
+      // (see juce_AudioFormat.h) -- delete it ourselves or it leaks.
+      delete stream;
+      outputStream_ = nullptr;
+    } else if (!stream->getStatus().wasOk()) {
+      // createWriterFor only checks that the stream pointer is non-null, not
+      // whether the underlying file actually opened -- a stream whose open
+      // failed (e.g. a missing parent directory, permission denied) still
+      // produces a non-null writer here. Treat that the same as an open
+      // failure: deleting writer_ also deletes the stream it owns.
+      delete writer_;
+      writer_ = nullptr;
+      outputStream_ = nullptr;
+    } else {
+      // Non-owning: writer_ owns and will delete this stream. Only ever
+      // dereferenced while writer_ is non-null, i.e. while it's still alive.
+      outputStream_ = stream;
+    }
   }
 
   ~FileWriter() { close(); };
 
-  void write(juce::AudioBuffer<float>& buffer) {
-    if (writer_ != nullptr) {
-      juce::AudioBuffer<float> toWrite;
-      toWrite.setDataToReferTo(&buffer.getArrayOfWritePointers()[firstChannel_],
-                               numChannels_, buffer.getNumSamples());
-      writer_->writeFromAudioSampleBuffer(toWrite, 0, buffer.getNumSamples());
+  // Returns whether the underlying file was successfully opened for writing.
+  bool isOpen() const { return writer_ != nullptr; }
+
+  // Returns false (and writes nothing) if the writer failed to open, or if
+  // the write itself fails (e.g. disk full, WAV 4GB size limit exceeded).
+  bool write(juce::AudioBuffer<float>& buffer) {
+    if (writer_ == nullptr) {
+      return false;
+    }
+    juce::AudioBuffer<float> toWrite;
+    toWrite.setDataToReferTo(&buffer.getArrayOfWritePointers()[firstChannel_],
+                             numChannels_, buffer.getNumSamples());
+    const bool kWriteOk =
+        writer_->writeFromAudioSampleBuffer(toWrite, 0, buffer.getNumSamples());
+    if (kWriteOk) {
       framesWritten += buffer.getNumSamples();
     }
+    return kWriteOk;
   }
 
-  void close() {
-    if (writer_ != nullptr) {
-      writer_->flush();
-      delete writer_;
-      writer_ = nullptr;
+  // Flushes and closes the writer. Returns true if there was nothing to
+  // close (never opened, or already closed), or if flushing succeeded and
+  // the underlying stream reports no error. A failure purely in the final
+  // header rewrite (which JUCE performs in the writer's destructor with no
+  // status return) cannot be detected here -- this is a best-effort check.
+  bool close() {
+    if (writer_ == nullptr) {
+      return true;
     }
+    const bool kFlushOk = writer_->flush();
+    const bool kStreamOk =
+        outputStream_ == nullptr || outputStream_->getStatus().wasOk();
+    delete writer_;
+    writer_ = nullptr;
+    outputStream_ = nullptr;
+    return kFlushOk && kStreamOk;
   }
 
   std::string getFilePath() {
@@ -67,6 +108,10 @@ class FileWriter {
 
  private:
   juce::AudioFormatWriter* writer_;
+  // Non-owning observer of the stream writer_ owns; used only to query
+  // write-error status at close() time. See constructor/close() for the
+  // lifetime argument.
+  juce::FileOutputStream* outputStream_;
   juce::File outputFile_;
   int framesWritten;
   int numChannels_;

--- a/common/processors/file_output/WavFileOutputProcessor.cpp
+++ b/common/processors/file_output/WavFileOutputProcessor.cpp
@@ -14,6 +14,9 @@
 
 #include "WavFileOutputProcessor.h"
 
+#include <logger/logger.h>
+
+#include "WriteFailureClassifier.h"
 #include "data_repository/implementation/FileExportRepository.h"
 #include "data_repository/implementation/RoomSetupRepository.h"
 #include "data_structures/src/FileExport.h"
@@ -33,7 +36,19 @@ WavFileOutputProcessor::WavFileOutputProcessor(
 }
 
 WavFileOutputProcessor::~WavFileOutputProcessor() {
+  *isAlive_ = false;
   fileExportRepository_.deregisterListener(this);
+}
+
+void WavFileOutputProcessor::deferRepositoryUpdate(
+    std::function<void(FileExport&)> mutator) {
+  auto isAlive = isAlive_;
+  postToMessageThread([this, isAlive, mutator] {
+    if (!*isAlive) return;
+    FileExport config = fileExportRepository_.get();
+    mutator(config);
+    fileExportRepository_.update(config);
+  });
 }
 
 //==============================================================================
@@ -56,6 +71,7 @@ void WavFileOutputProcessor::processBlock(juce::AudioBuffer<float>& buffer,
              // process anything and should avoid blocking
   }
 
+  bool writeFailed = false;
   if (performingRender_ && fileWriter_ != nullptr) {
     // If the current position is between the configured start and end position,
     // write to the file. Else do nothing
@@ -66,13 +82,31 @@ void WavFileOutputProcessor::processBlock(juce::AudioBuffer<float>& buffer,
           static_cast<long>(*position->getTimeInSeconds() * sampleRate_);
       if ((endSampleIdx_ == 0) || (currentSample >= startSampleIdx_ &&
                                    currentSample <= endSampleIdx_)) {
-        fileWriter_->write(buffer);
+        writeFailed = !fileWriter_->write(buffer);
       }
     } else {
-      fileWriter_->write(buffer);
+      writeFailed = !fileWriter_->write(buffer);
     }
   }
   lock_.exit();
+
+  recordWriteFailureIfAny(!writeFailed);
+}
+
+void WavFileOutputProcessor::recordWriteFailureIfAny(bool writeSucceeded) {
+  if (writeSucceeded) {
+    return;
+  }
+  // A frame write failed mid-export (e.g. disk full, WAV size limit
+  // exceeded). Record it unless a more specific error is already on record,
+  // mirroring the guard used by FileOutputProcessor for the IAMF/per-element
+  // paths. Deferred via deferRepositoryUpdate() -- see its declaration for
+  // why this can't call fileExportRepository_.update() synchronously.
+  deferRepositoryUpdate([](FileExport& config) {
+    if (config.getExportError() == kNoError) {
+      config.setExportError(kFileWriteFailed);
+    }
+  });
 }
 
 void WavFileOutputProcessor::setNonRealtime(bool isNonRealtime) noexcept {
@@ -85,16 +119,44 @@ void WavFileOutputProcessor::setNonRealtime(bool isNonRealtime) noexcept {
     endSampleIdx_ = configParams.getEndSampleIdx();
     if ((configParams.getAudioFileFormat() == AudioFileFormat::WAV) &&
         configParams.getExportAudio()) {
+      // Every export begins from a clean slate, mirroring
+      // FileOutputProcessor::initializeFileExport. Deferred via
+      // deferRepositoryUpdate() -- see its declaration for why this can't
+      // call fileExportRepository_.update() synchronously.
+      deferRepositoryUpdate(
+          [](FileExport& config) { config.setExportError(kNoError); });
+
       fileWriter_ = new FileWriter(
           configParams.getExportFile(), configParams.getSampleRate(),
           roomSetup.getSpeakerLayout().getRoomSpeakerLayout().getNumChannels(),
           0, configParams.getBitDepth(), configParams.getAudioCodec());
+      if (!fileWriter_->isOpen()) {
+        const std::string kFailedFilePath = fileWriter_->getFilePath();
+        LOG_ERROR(0,
+                  "WavFileOutputProcessor: Failed to open file for writing: " +
+                      kFailedFilePath);
+        deferRepositoryUpdate([kFailedFilePath](FileExport& config) {
+          if (config.getExportError() == kNoError) {
+            config.setExportError(
+                classifyWriteFailure(juce::String(kFailedFilePath)));
+          }
+        });
+      }
       performingRender_ = true;
     }
   } else {
     // Complete Rendering
     if (fileWriter_ != nullptr) {
-      fileWriter_->close();
+      if (!fileWriter_->close()) {
+        // The writer was opened successfully but failed to close/flush --
+        // an unreported write failure. Only escalate if nothing more
+        // specific has already been recorded earlier in this export.
+        deferRepositoryUpdate([](FileExport& config) {
+          if (config.getExportError() == kNoError) {
+            config.setExportError(kFileWriteFailed);
+          }
+        });
+      }
       delete fileWriter_;
       fileWriter_ = nullptr;
     }

--- a/common/processors/file_output/WavFileOutputProcessor.cpp
+++ b/common/processors/file_output/WavFileOutputProcessor.cpp
@@ -36,13 +36,8 @@ WavFileOutputProcessor::WavFileOutputProcessor(
 }
 
 WavFileOutputProcessor::~WavFileOutputProcessor() {
-  // isAlive_ is read (via deferRepositoryUpdate()'s captured task) and
-  // written here without any lock; that's only race-free if destruction and
-  // every deferred callback run on the message thread. Only assert the
-  // invariant when a MessageManager actually exists -- the unit test binary
-  // has none (JUCE_MODAL_LOOPS_PERMITTED is 0, no message loop), and
-  // getInstanceWithoutCreating() returning null there is expected, not a
-  // violation.
+  // Ensure this is either deleted by a unit test (nullptr check) or 
+  // by the message thread since deletion by the audio thread is not safe (lock_ is non-reentrant)
   jassert(juce::MessageManager::getInstanceWithoutCreating() == nullptr ||
           juce::MessageManager::getInstanceWithoutCreating()
               ->isThisTheMessageThread());
@@ -108,13 +103,9 @@ void WavFileOutputProcessor::recordWriteFailureIfAny(bool writeSucceeded) {
     return;
   }
   // A persistent failure (disk full, WAV size limit exceeded) fails every
-  // subsequent block, and an offline bounce typically doesn't pump the
-  // message loop between blocks -- without this guard, each failing block
-  // would queue its own deferRepositoryUpdate() closure, and hundreds of
-  // thousands could pile up before the first one drains. Only the first
-  // failure of an export needs to be recorded, so exchange() both checks and
-  // claims that slot atomically; hasRecordedWriteFailure_ is reset in
-  // setNonRealtime() at the start of the next export.
+  // subsequent block. Only the first failure of an export needs to be recorded.'
+  // exchange() both checks and claims that slot atomically; 
+  // hasRecordedWriteFailure_ is reset in setNonRealtime() at the start of the next export.
   if (hasRecordedWriteFailure_.exchange(true)) {
     return;
   }

--- a/common/processors/file_output/WavFileOutputProcessor.cpp
+++ b/common/processors/file_output/WavFileOutputProcessor.cpp
@@ -36,6 +36,16 @@ WavFileOutputProcessor::WavFileOutputProcessor(
 }
 
 WavFileOutputProcessor::~WavFileOutputProcessor() {
+  // isAlive_ is read (via deferRepositoryUpdate()'s captured task) and
+  // written here without any lock; that's only race-free if destruction and
+  // every deferred callback run on the message thread. Only assert the
+  // invariant when a MessageManager actually exists -- the unit test binary
+  // has none (JUCE_MODAL_LOOPS_PERMITTED is 0, no message loop), and
+  // getInstanceWithoutCreating() returning null there is expected, not a
+  // violation.
+  jassert(juce::MessageManager::getInstanceWithoutCreating() == nullptr ||
+          juce::MessageManager::getInstanceWithoutCreating()
+              ->isThisTheMessageThread());
   *isAlive_ = false;
   fileExportRepository_.deregisterListener(this);
 }
@@ -97,11 +107,21 @@ void WavFileOutputProcessor::recordWriteFailureIfAny(bool writeSucceeded) {
   if (writeSucceeded) {
     return;
   }
-  // A frame write failed mid-export (e.g. disk full, WAV size limit
-  // exceeded). Record it unless a more specific error is already on record,
-  // mirroring the guard used by FileOutputProcessor for the IAMF/per-element
-  // paths. Deferred via deferRepositoryUpdate() -- see its declaration for
-  // why this can't call fileExportRepository_.update() synchronously.
+  // A persistent failure (disk full, WAV size limit exceeded) fails every
+  // subsequent block, and an offline bounce typically doesn't pump the
+  // message loop between blocks -- without this guard, each failing block
+  // would queue its own deferRepositoryUpdate() closure, and hundreds of
+  // thousands could pile up before the first one drains. Only the first
+  // failure of an export needs to be recorded, so exchange() both checks and
+  // claims that slot atomically; hasRecordedWriteFailure_ is reset in
+  // setNonRealtime() at the start of the next export.
+  if (hasRecordedWriteFailure_.exchange(true)) {
+    return;
+  }
+  // Record it unless a more specific error is already on record, mirroring
+  // the guard used by FileOutputProcessor for the IAMF/per-element paths.
+  // Deferred via deferRepositoryUpdate() -- see its declaration for why this
+  // can't call fileExportRepository_.update() synchronously.
   deferRepositoryUpdate([](FileExport& config) {
     if (config.getExportError() == kNoError) {
       config.setExportError(kFileWriteFailed);
@@ -125,8 +145,9 @@ void WavFileOutputProcessor::setNonRealtime(bool isNonRealtime) noexcept {
       // call fileExportRepository_.update() synchronously.
       deferRepositoryUpdate(
           [](FileExport& config) { config.setExportError(kNoError); });
+      hasRecordedWriteFailure_ = false;
 
-      fileWriter_ = new FileWriter(
+      fileWriter_ = createFileWriter(
           configParams.getExportFile(), configParams.getSampleRate(),
           roomSetup.getSpeakerLayout().getRoomSpeakerLayout().getNumChannels(),
           0, configParams.getBitDepth(), configParams.getAudioCodec());

--- a/common/processors/file_output/WavFileOutputProcessor.cpp
+++ b/common/processors/file_output/WavFileOutputProcessor.cpp
@@ -36,8 +36,9 @@ WavFileOutputProcessor::WavFileOutputProcessor(
 }
 
 WavFileOutputProcessor::~WavFileOutputProcessor() {
-  // Ensure this is either deleted by a unit test (nullptr check) or 
-  // by the message thread since deletion by the audio thread is not safe (lock_ is non-reentrant)
+  // Ensure this is either deleted by a unit test (nullptr check) or
+  // by the message thread since deletion by the audio thread is not safe (lock_
+  // is non-reentrant)
   jassert(juce::MessageManager::getInstanceWithoutCreating() == nullptr ||
           juce::MessageManager::getInstanceWithoutCreating()
               ->isThisTheMessageThread());
@@ -103,9 +104,10 @@ void WavFileOutputProcessor::recordWriteFailureIfAny(bool writeSucceeded) {
     return;
   }
   // A persistent failure (disk full, WAV size limit exceeded) fails every
-  // subsequent block. Only the first failure of an export needs to be recorded.'
-  // exchange() both checks and claims that slot atomically; 
-  // hasRecordedWriteFailure_ is reset in setNonRealtime() at the start of the next export.
+  // subsequent block. Only the first failure of an export needs to be
+  // recorded.' exchange() both checks and claims that slot atomically;
+  // hasRecordedWriteFailure_ is reset in setNonRealtime() at the start of the
+  // next export.
   if (hasRecordedWriteFailure_.exchange(true)) {
     return;
   }

--- a/common/processors/file_output/WavFileOutputProcessor.h
+++ b/common/processors/file_output/WavFileOutputProcessor.h
@@ -75,11 +75,6 @@ class WavFileOutputProcessor : public ProcessorBase,
     juce::MessageManager::callAsync(std::move(task));
   }
 
-  // Constructs the FileWriter used for the current export. Virtual so tests
-  // can return a fake that opens successfully (via the real FileWriter
-  // constructor it wraps) but simulates a write()/close() failure -- the
-  // production path can only reach that branch via disk-full/WAV-4GB-cap
-  // conditions, which aren't practical to reproduce directly in a test.
   virtual FileWriter* createFileWriter(const juce::String& filename,
                                        double sampleRate, int numChannels,
                                        int firstChannel, int bitDepth,
@@ -129,23 +124,9 @@ class WavFileOutputProcessor : public ProcessorBase,
   long startSampleIdx_;
   long endSampleIdx_;
   juce::SpinLock lock_;
-  // Set once recordWriteFailureIfAny() has queued a deferRepositoryUpdate()
-  // for the current export, so a persistent failure (disk full, WAV 4GB cap)
-  // doesn't queue a fresh callAsync closure for every subsequent failing
-  // block -- only the state change matters, and it only needs to happen
-  // once. Reset to false at the start of each export in setNonRealtime().
   std::atomic<bool> hasRecordedWriteFailure_ = false;
-  // Flipped to false at the start of the destructor so a
-  // deferRepositoryUpdate() callback that fires after this processor is
-  // destroyed can detect that and bail out instead of touching freed memory.
-  // Shared (not owned outright) so the async callback can safely hold its own
-  // reference. This only closes the destroyed-then-callback-runs-later case;
-  // it relies on destruction and every deferred callback both running on the
-  // message thread (so JUCE can never interleave them and race on
-  // fileExportRepository_) -- see the destructor's assertion of that
-  // invariant.
   std::shared_ptr<std::atomic<bool>> isAlive_ =
-      std::make_shared<std::atomic<bool>>(true);
+      std::make_shared<std::atomic<bool>>(true); // Safety valve for deferred updates
   //==============================================================================
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WavFileOutputProcessor)
 };

--- a/common/processors/file_output/WavFileOutputProcessor.h
+++ b/common/processors/file_output/WavFileOutputProcessor.h
@@ -126,7 +126,8 @@ class WavFileOutputProcessor : public ProcessorBase,
   juce::SpinLock lock_;
   std::atomic<bool> hasRecordedWriteFailure_ = false;
   std::shared_ptr<std::atomic<bool>> isAlive_ =
-      std::make_shared<std::atomic<bool>>(true); // Safety valve for deferred updates
+      std::make_shared<std::atomic<bool>>(
+          true);  // Safety valve for deferred updates
   //==============================================================================
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WavFileOutputProcessor)
 };

--- a/common/processors/file_output/WavFileOutputProcessor.h
+++ b/common/processors/file_output/WavFileOutputProcessor.h
@@ -116,10 +116,11 @@ class WavFileOutputProcessor : public ProcessorBase,
   long startSampleIdx_;
   long endSampleIdx_;
   juce::SpinLock lock_;
-  // Flipped to false at the start of the destructor so a deferRepositoryUpdate()
-  // callback that fires after this processor is destroyed can detect that
-  // and bail out instead of touching freed memory. Shared (not owned
-  // outright) so the async callback can safely hold its own reference.
+  // Flipped to false at the start of the destructor so a
+  // deferRepositoryUpdate() callback that fires after this processor is
+  // destroyed can detect that and bail out instead of touching freed memory.
+  // Shared (not owned outright) so the async callback can safely hold its own
+  // reference.
   std::shared_ptr<std::atomic<bool>> isAlive_ =
       std::make_shared<std::atomic<bool>>(true);
   //==============================================================================

--- a/common/processors/file_output/WavFileOutputProcessor.h
+++ b/common/processors/file_output/WavFileOutputProcessor.h
@@ -19,6 +19,8 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_dsp/juce_dsp.h>
 
+#include <atomic>
+#include <functional>
 #include <memory>
 
 #include "../processor_base/ProcessorBase.h"
@@ -29,8 +31,12 @@
 #include "user_metadata.pb.h"
 
 //==============================================================================
-class WavFileOutputProcessor final : public ProcessorBase,
-                                     public juce::ValueTree::Listener {
+// Not `final`: a test-only subclass overrides postToMessageThread() to run
+// deferred repository updates synchronously (there's no running JUCE
+// message loop in the unit test binary). See postToMessageThread()'s
+// comment.
+class WavFileOutputProcessor : public ProcessorBase,
+                               public juce::ValueTree::Listener {
  public:
   //==============================================================================
   WavFileOutputProcessor(FileExportRepository& fileExportRepository,
@@ -58,7 +64,49 @@ class WavFileOutputProcessor final : public ProcessorBase,
   //==============================================================================
   const juce::String getName() { return "WaveFileOutput"; }
 
+ protected:
+  // Posts `task` to run on the message thread. Defaults to
+  // juce::MessageManager::callAsync; overridden by tests (which have no
+  // running JUCE message loop -- runDispatchLoopUntil isn't even compiled
+  // in, since JUCE_MODAL_LOOPS_PERMITTED is 0 for this plugin build) to
+  // invoke `task` immediately instead. See deferRepositoryUpdate() for why
+  // production code needs this deferred at all.
+  virtual void postToMessageThread(std::function<void()> task) {
+    juce::MessageManager::callAsync(std::move(task));
+  }
+
  private:
+  // Records a kFileWriteFailed ExportError (unless a more specific error is
+  // already on record) when a FileWriter::write() call fails.
+  void recordWriteFailureIfAny(bool writeSucceeded);
+
+  // Defers a FileExport mutation to the next message-loop turn (via
+  // postToMessageThread), running `mutator` against a config fetched fresh
+  // at execution time (not capture time), then writing it back. This
+  // processor is registered as a juce::ValueTree::Listener on
+  // fileExportRepository_ (see the constructor), and production callers
+  // (e.g. the export button handler) update that same repository with a
+  // read-modify-write of a FULL FileExport snapshot
+  // (`config = repo.get(); config.setX(...); repo.update(config)`).
+  // FileExportRepository::update() fires ValueTree listener callbacks
+  // SYNCHRONOUSLY, mid-copyPropertiesFrom, before that caller's own,
+  // now-stale snapshot has finished being applied property-by-property. If
+  // this method wrote to the repository synchronously from inside that
+  // callback chain (checkManualExportStartStop -> setNonRealtime), two
+  // things break: (1) setNonRealtime()'s lock_ is non-reentrant, so a
+  // synchronous update() that re-enters setNonRealtime() via the listener
+  // deadlocks; (2) even without the lock, the caller's own copyPropertiesFrom
+  // loop would go on to reapply ITS stale (pre-failure) exportError value
+  // for a property processed after the one that triggered this callback
+  // (FileExport.h declares manualExport before exportError, so this is not
+  // a rare race -- it reproduces every time), silently clobbering whatever
+  // this method just wrote. Deferring (the same pattern ExportErrorBanner
+  // already uses for this repository, see its valueTreePropertyChanged)
+  // guarantees this runs after the entire triggering call stack -- including
+  // the caller's copyPropertiesFrom loop -- has fully unwound, so neither
+  // hazard applies.
+  void deferRepositoryUpdate(std::function<void(FileExport&)> mutator);
+
   bool performingRender_;  // True if we are rendering in offline mode
   FileExportRepository& fileExportRepository_;
   RoomSetupRepository& roomSetupRepository_;
@@ -68,6 +116,12 @@ class WavFileOutputProcessor final : public ProcessorBase,
   long startSampleIdx_;
   long endSampleIdx_;
   juce::SpinLock lock_;
+  // Flipped to false at the start of the destructor so a deferRepositoryUpdate()
+  // callback that fires after this processor is destroyed can detect that
+  // and bail out instead of touching freed memory. Shared (not owned
+  // outright) so the async callback can safely hold its own reference.
+  std::shared_ptr<std::atomic<bool>> isAlive_ =
+      std::make_shared<std::atomic<bool>>(true);
   //==============================================================================
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WavFileOutputProcessor)
 };

--- a/common/processors/file_output/WavFileOutputProcessor.h
+++ b/common/processors/file_output/WavFileOutputProcessor.h
@@ -75,6 +75,19 @@ class WavFileOutputProcessor : public ProcessorBase,
     juce::MessageManager::callAsync(std::move(task));
   }
 
+  // Constructs the FileWriter used for the current export. Virtual so tests
+  // can return a fake that opens successfully (via the real FileWriter
+  // constructor it wraps) but simulates a write()/close() failure -- the
+  // production path can only reach that branch via disk-full/WAV-4GB-cap
+  // conditions, which aren't practical to reproduce directly in a test.
+  virtual FileWriter* createFileWriter(const juce::String& filename,
+                                       double sampleRate, int numChannels,
+                                       int firstChannel, int bitDepth,
+                                       AudioCodec codec) {
+    return new FileWriter(filename, sampleRate, numChannels, firstChannel,
+                          bitDepth, codec);
+  }
+
  private:
   // Records a kFileWriteFailed ExportError (unless a more specific error is
   // already on record) when a FileWriter::write() call fails.
@@ -116,11 +129,21 @@ class WavFileOutputProcessor : public ProcessorBase,
   long startSampleIdx_;
   long endSampleIdx_;
   juce::SpinLock lock_;
+  // Set once recordWriteFailureIfAny() has queued a deferRepositoryUpdate()
+  // for the current export, so a persistent failure (disk full, WAV 4GB cap)
+  // doesn't queue a fresh callAsync closure for every subsequent failing
+  // block -- only the state change matters, and it only needs to happen
+  // once. Reset to false at the start of each export in setNonRealtime().
+  std::atomic<bool> hasRecordedWriteFailure_ = false;
   // Flipped to false at the start of the destructor so a
   // deferRepositoryUpdate() callback that fires after this processor is
   // destroyed can detect that and bail out instead of touching freed memory.
   // Shared (not owned outright) so the async callback can safely hold its own
-  // reference.
+  // reference. This only closes the destroyed-then-callback-runs-later case;
+  // it relies on destruction and every deferred callback both running on the
+  // message thread (so JUCE can never interleave them and race on
+  // fileExportRepository_) -- see the destructor's assertion of that
+  // invariant.
   std::shared_ptr<std::atomic<bool>> isAlive_ =
       std::make_shared<std::atomic<bool>>(true);
   //==============================================================================

--- a/common/processors/file_output/WriteFailureClassifier.cpp
+++ b/common/processors/file_output/WriteFailureClassifier.cpp
@@ -1,0 +1,60 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "WriteFailureClassifier.h"
+
+#include <logger/logger.h>
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+ExportError classifyWriteFailure(const juce::String& path) {
+  try {
+    const std::filesystem::path kParentDir =
+        std::filesystem::path(path.toStdString()).parent_path();
+    if (kParentDir.empty()) {
+      // No parent directory to probe -- don't fall back to probing the
+      // process's current working directory.
+      return kFileWriteFailed;
+    }
+    const std::filesystem::path kProbePath =
+        kParentDir /
+        (".acx_write_probe_" + juce::Uuid().toString().toStdString() + ".tmp");
+    std::ofstream probe(kProbePath);
+    if (!probe.is_open()) {
+      const int kProbeErrno = errno;
+      if (kProbeErrno == EACCES || kProbeErrno == EPERM ||
+          kProbeErrno == EROFS) {
+        return kPermissionDenied;
+      }
+      return kFileWriteFailed;
+    }
+    probe.close();
+    std::error_code removeEc;
+    std::filesystem::remove(kProbePath, removeEc);
+    if (removeEc) {
+      LOG_WARNING(0,
+                  "classifyWriteFailure: Failed to remove write-probe file: " +
+                      removeEc.message());
+    }
+    // The probe succeeded, so the parent directory is actually writable --
+    // the real failure must be something else (e.g. disk full, invalid
+    // filename).
+    return kFileWriteFailed;
+  } catch (const std::filesystem::filesystem_error&) {
+    return kFileWriteFailed;
+  }
+}

--- a/common/processors/file_output/WriteFailureClassifier.h
+++ b/common/processors/file_output/WriteFailureClassifier.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include "data_structures/src/FileExport.h"
+
+// Classifies a file write failure by probing whether the parent directory of
+// `path` is actually writable. The real write attempt has already failed by
+// the time this runs, so this only distinguishes a permission problem from
+// some other write failure (disk full, invalid filename, etc.). Shared by
+// every writer path (IAMF, per-audio-element WAV, direct WAV export) so
+// classification stays consistent across all of them.
+//
+// The probe filename is unique per call (rather than a fixed name) so a
+// symlink cannot be pre-planted at a predictable path in a shared/multi-user
+// export destination, and so two concurrent exports to the same folder
+// cannot collide on the same probe file.
+ExportError classifyWriteFailure(const juce::String& path);

--- a/common/processors/processors.cpp
+++ b/common/processors/processors.cpp
@@ -20,6 +20,7 @@
 #include "file_output/FileOutputProcessor.cpp"
 #include "file_output/FileOutputProcessor_PremierePro.cpp"
 #include "file_output/WavFileOutputProcessor.cpp"
+#include "file_output/WriteFailureClassifier.cpp"
 #include "file_output/iamf_export_utils/IAMFExportUtil.cpp"
 #include "file_output/iamf_export_utils/IAMFFileReader.cpp"
 #include "file_output/iamf_export_utils/IAMFFileWriter.cpp"

--- a/common/processors/tests/CMakeLists.txt
+++ b/common/processors/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 eclipsa_add_test(test_fio_processor FileOutputProcessor_test.cpp "processors;iamf")
 eclipsa_add_test(test_fio_processor FileOutputProcessor_PremierePro_test.cpp "processors;iamf")
+eclipsa_add_test(test_wav_fio_processor WavFileOutputProcessor_test.cpp "processors")
 eclipsa_add_test(test_processor_base ProcessorBase_test.cpp "processors;juce::juce_audio_utils")
 eclipsa_add_test(test_render_processor Render_test.cpp "processors;juce::juce_audio_utils;iamf")
 eclipsa_add_test(test_libear_sanity libear_test.cpp "libear")

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -659,6 +659,45 @@ TEST_F(FileOutputTests, permission_denied_export_path) {
             ExportError::kPermissionDenied);
 }
 
+// An audio-element name containing a path separator makes its derived WAV
+// filename (`<export>_<name>.wav`) resolve into a non-existent subdirectory,
+// so only that per-element writer fails to open -- the IAMF file uses a
+// separate, short, valid path (unaffected by the element name) and opens
+// fine. Before this fix, that failure was silently dropped: the export
+// "succeeded" with a WAV stem missing. (An oversized name was tried first
+// instead of a path separator, but iamf-tools itself rejects overlong
+// annotation strings, which confounds the IAMF path too -- a path separator
+// only affects the filesystem side.)
+TEST_F(FileOutputTests, per_element_wav_open_failure_bad_name_classified) {
+  const juce::Uuid kAE =
+      addAudioElement(Speakers::kStereo, "nonexistent_subdir/element");
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  bounceAudio(fio_proc, audioElementRepository);
+
+  // The IAMF file itself (a separate, valid path) still opens and completes.
+  EXPECT_TRUE(std::filesystem::exists(iamfOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kFileWriteFailed);
+}
+
+// Happy-path regression guard: an export where every writer (IAMF and every
+// per-audio-element WAV writer) opens, writes, and closes successfully must
+// leave ExportError at kNoError -- the per-element open/write/close checks
+// added by this fix must never misfire on the success path.
+TEST_F(FileOutputTests, per_element_wav_all_writers_succeed_no_error) {
+  const juce::Uuid kAE1 = addAudioElement(Speakers::kStereo, "Element One");
+  const juce::Uuid kAE2 = addAudioElement(Speakers::kStereo, "Element Two");
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE1, kAE2});
+
+  bounceAudio(fio_proc, audioElementRepository);
+
+  EXPECT_TRUE(std::filesystem::exists(iamfOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+}
+
 namespace {
 // classifyWriteFailure is `protected` (it's only meant to be called from
 // FileOutputProcessor itself) and `static` (stateless), so a derived class

--- a/common/processors/tests/WavFileOutputProcessor_test.cpp
+++ b/common/processors/tests/WavFileOutputProcessor_test.cpp
@@ -1,0 +1,207 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <juce_data_structures/juce_data_structures.h>
+
+#include <filesystem>
+#include <functional>
+#include <vector>
+
+#include "data_repository/implementation/FileExportRepository.h"
+#include "data_repository/implementation/RoomSetupRepository.h"
+#include "data_structures/src/FileExport.h"
+#include "processors/file_output/WavFileOutputProcessor.h"
+
+namespace {
+class TestFileExportRepository : public FileExportRepository {
+ public:
+  TestFileExportRepository() : FileExportRepository(juce::ValueTree{"test"}) {}
+};
+
+class TestRoomSetupRepository : public RoomSetupRepository {
+ public:
+  TestRoomSetupRepository() : RoomSetupRepository(juce::ValueTree{"test"}) {}
+};
+
+// Queues WavFileOutputProcessor's deferred repository updates (see
+// deferRepositoryUpdate()/postToMessageThread()) instead of posting them to
+// juce::MessageManager::callAsync -- there is no running JUCE message loop
+// in this test binary to pump (runDispatchLoopUntil isn't even compiled in;
+// JUCE_MODAL_LOOPS_PERMITTED is 0 for this plugin build). Running the tasks
+// immediately/synchronously here would defeat the very thing being tested:
+// both the deadlock and the clobbering hazard deferRepositoryUpdate() exists
+// to avoid only manifest when a write happens nested inside the triggering
+// update() call's own call stack. Queuing and draining explicitly via
+// runPendingTasks() -- called only after that outer call has fully
+// returned -- reproduces the real timing guarantee callAsync provides,
+// without needing a real message loop. Production code always goes through
+// the real base-class implementation.
+class TestableWavFileOutputProcessor : public WavFileOutputProcessor {
+ public:
+  using WavFileOutputProcessor::WavFileOutputProcessor;
+
+  void runPendingTasks() {
+    std::vector<std::function<void()>> tasks;
+    tasks.swap(pendingTasks_);
+    for (auto& task : tasks) task();
+  }
+
+ protected:
+  void postToMessageThread(std::function<void()> task) override {
+    pendingTasks_.push_back(std::move(task));
+  }
+
+ private:
+  std::vector<std::function<void()>> pendingTasks_;
+};
+
+class WavFileOutputTests : public ::testing::Test {
+ protected:
+  TestFileExportRepository fileExportRepository;
+  TestRoomSetupRepository roomSetupRepository;
+  TestableWavFileOutputProcessor processor{fileExportRepository,
+                                           roomSetupRepository};
+};
+}  // namespace
+
+// WavFileOutputProcessor registers itself as a listener on
+// fileExportRepository (see its constructor); FileExportRepository::update()
+// fires that listener synchronously on the calling thread. Toggling
+// ManualExport through the repository -- exactly how production code (the
+// export button in FileExportScreen.cpp) drives this processor -- exercises
+// that same re-entrant path. Before the deferRepositoryUpdate() fix, an open
+// failure here recorded the ExportError via a repository update issued
+// synchronously from inside that listener callback, which re-entered
+// setNonRealtime()'s non-reentrant lock_ and deadlocked. This test hanging
+// (rather than completing) is the regression signal for that bug.
+TEST_F(WavFileOutputTests, open_failure_via_manual_export_toggle_does_not_deadlock) {
+  FileExport config = fileExportRepository.get();
+  config.setAudioFileFormat(AudioFileFormat::WAV);
+  config.setExportAudio(true);
+  config.setSampleRate(48000);
+  config.setBitDepth(16);
+  config.setAudioCodec(AudioCodec::LPCM);
+  config.setExportFile("/invalid_path/test.wav");
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+
+  // Flipping ManualExport to true synchronously triggers this processor's
+  // own valueTreePropertyChanged -> checkManualExportStartStop ->
+  // setNonRealtime path.
+  config.setManualExport(true);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+
+  EXPECT_NE(fileExportRepository.get().getExportError(), ExportError::kNoError);
+
+  // Stopping the (failed) render must also complete without hanging, and
+  // must not crash on the null/never-opened writer.
+  config = fileExportRepository.get();
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+}
+
+// Happy-path regression guard mirroring FileOutputTests' equivalent: a
+// successful open/close on a valid path must leave ExportError at kNoError.
+TEST_F(WavFileOutputTests, successful_export_leaves_no_error) {
+  const std::filesystem::path kOutPath =
+      std::filesystem::current_path() / "wav_output_test.wav";
+  std::filesystem::remove(kOutPath);
+
+  FileExport config = fileExportRepository.get();
+  config.setAudioFileFormat(AudioFileFormat::WAV);
+  config.setExportAudio(true);
+  config.setSampleRate(48000);
+  config.setBitDepth(16);
+  config.setAudioCodec(AudioCodec::LPCM);
+  config.setExportFile(kOutPath.string());
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+
+  config.setManualExport(true);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+
+  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+
+  config = fileExportRepository.get();
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+
+  EXPECT_TRUE(std::filesystem::exists(kOutPath));
+  std::filesystem::remove(kOutPath);
+}
+
+// Regression test for a subtler hazard than the deadlock above: the real
+// export button handler (rendererplugin/src/screens/FileExportScreen.cpp)
+// does `config = repo.get(); config.setManualExport(!...); repo.update(config)`
+// -- a read-modify-write of a FULL FileExport snapshot. Before
+// deferRepositoryUpdate(), a synchronous classification write issued from
+// inside the listener callback this triggers got silently overwritten
+// moments later, when that same caller's copyPropertiesFrom loop went on to
+// reapply its own stale (pre-attempt) exportError property (FileExport.h
+// declares manualExport before exportError, so the loop processes
+// exportError second, in every call). This test reproduces that exact
+// caller pattern across a failed attempt followed by a successful retry,
+// and asserts the retry's success is neither clobbered by, nor leaks, the
+// prior failure.
+TEST_F(WavFileOutputTests, retry_after_failure_does_not_clobber_or_leak_error) {
+  const std::filesystem::path kOutPath =
+      std::filesystem::current_path() / "wav_retry_test.wav";
+  std::filesystem::remove(kOutPath);
+
+  // First attempt: invalid path, fails.
+  FileExport config = fileExportRepository.get();
+  config.setAudioFileFormat(AudioFileFormat::WAV);
+  config.setExportAudio(true);
+  config.setSampleRate(48000);
+  config.setBitDepth(16);
+  config.setAudioCodec(AudioCodec::LPCM);
+  config.setExportFile("/invalid_path/test.wav");
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+
+  config.setManualExport(true);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+  EXPECT_NE(fileExportRepository.get().getExportError(), ExportError::kNoError);
+
+  config = fileExportRepository.get();
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+
+  // Second attempt, mirroring FileExportScreen.cpp's export button handler
+  // exactly: the snapshot captured here still holds the failed ExportError
+  // from the first attempt, before flipping ManualExport and writing it
+  // back with everything else it doesn't intend to change.
+  config = fileExportRepository.get();
+  config.setExportFile(kOutPath.string());
+  config.setManualExport(!config.getManualExport());
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+
+  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+
+  config = fileExportRepository.get();
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+
+  EXPECT_TRUE(std::filesystem::exists(kOutPath));
+  std::filesystem::remove(kOutPath);
+}

--- a/common/processors/tests/WavFileOutputProcessor_test.cpp
+++ b/common/processors/tests/WavFileOutputProcessor_test.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "processors/file_output/WavFileOutputProcessor.h"
+
 #include <gtest/gtest.h>
 #include <juce_data_structures/juce_data_structures.h>
 
@@ -22,7 +24,6 @@
 #include "data_repository/implementation/FileExportRepository.h"
 #include "data_repository/implementation/RoomSetupRepository.h"
 #include "data_structures/src/FileExport.h"
-#include "processors/file_output/WavFileOutputProcessor.h"
 
 namespace {
 class TestFileExportRepository : public FileExportRepository {
@@ -86,7 +87,8 @@ class WavFileOutputTests : public ::testing::Test {
 // synchronously from inside that listener callback, which re-entered
 // setNonRealtime()'s non-reentrant lock_ and deadlocked. This test hanging
 // (rather than completing) is the regression signal for that bug.
-TEST_F(WavFileOutputTests, open_failure_via_manual_export_toggle_does_not_deadlock) {
+TEST_F(WavFileOutputTests,
+       open_failure_via_manual_export_toggle_does_not_deadlock) {
   FileExport config = fileExportRepository.get();
   config.setAudioFileFormat(AudioFileFormat::WAV);
   config.setExportAudio(true);

--- a/common/processors/tests/WavFileOutputProcessor_test.cpp
+++ b/common/processors/tests/WavFileOutputProcessor_test.cpp
@@ -253,12 +253,9 @@ TEST_F(WavFileOutputTests, retry_after_failure_does_not_clobber_or_leak_error) {
   std::filesystem::remove(kOutPath);
 }
 
-// Regression test for the HIGH review finding on PR #14:
-// recordWriteFailureIfAny() used to call deferRepositoryUpdate()
-// unconditionally on every failing processBlock, so a persistent failure
-// (disk full, WAV 4GB cap) during an offline bounce -- which doesn't pump
-// the message loop between blocks -- could queue hundreds of thousands of
-// callAsync closures before the first one drained. This reproduces the
+// Regression for recordWriteFailureIfAny() used to call deferRepositoryUpdate()
+// unconditionally on every failing processBlock, ensuring
+// persistent failures don't queue more than once. This reproduces the
 // open-succeeds-then-every-write-fails shape via FakeFileWriter and asserts
 // exactly one closure is queued no matter how many blocks fail.
 TEST_F(WavFileOutputTests,

--- a/common/processors/tests/WavFileOutputProcessor_test.cpp
+++ b/common/processors/tests/WavFileOutputProcessor_test.cpp
@@ -36,6 +36,31 @@ class TestRoomSetupRepository : public RoomSetupRepository {
   TestRoomSetupRepository() : RoomSetupRepository(juce::ValueTree{"test"}) {}
 };
 
+// Wraps a real FileWriter (so construction still performs a real open
+// against a real, writable path) but lets a test force write()/close() to
+// report failure afterward -- the only way to exercise the
+// write/close-after-successful-open branches in WavFileOutputProcessor,
+// since production only reaches them via disk-full/WAV-4GB-cap conditions.
+class FakeFileWriter : public FileWriter {
+ public:
+  using FileWriter::FileWriter;
+
+  bool write(juce::AudioBuffer<float>& buffer) override {
+    ++writeCallCount;
+    if (forceWriteFailure) return false;
+    return FileWriter::write(buffer);
+  }
+
+  bool close() override {
+    if (forceCloseFailure) return false;
+    return FileWriter::close();
+  }
+
+  bool forceWriteFailure = false;
+  bool forceCloseFailure = false;
+  int writeCallCount = 0;
+};
+
 // Queues WavFileOutputProcessor's deferred repository updates (see
 // deferRepositoryUpdate()/postToMessageThread()) instead of posting them to
 // juce::MessageManager::callAsync -- there is no running JUCE message loop
@@ -59,9 +84,29 @@ class TestableWavFileOutputProcessor : public WavFileOutputProcessor {
     for (auto& task : tasks) task();
   }
 
+  size_t pendingTaskCount() const { return pendingTasks_.size(); }
+
+  // Set before triggering an export start so the FileWriter it opens is a
+  // FakeFileWriter; the returned pointer is only valid for the lifetime of
+  // that export (WavFileOutputProcessor deletes it on close).
+  bool forceWriteFailure = false;
+  bool forceCloseFailure = false;
+  FakeFileWriter* lastFakeWriter = nullptr;
+
  protected:
   void postToMessageThread(std::function<void()> task) override {
     pendingTasks_.push_back(std::move(task));
+  }
+
+  FileWriter* createFileWriter(const juce::String& filename, double sampleRate,
+                               int numChannels, int firstChannel, int bitDepth,
+                               AudioCodec codec) override {
+    auto* fake = new FakeFileWriter(filename, sampleRate, numChannels,
+                                    firstChannel, bitDepth, codec);
+    fake->forceWriteFailure = forceWriteFailure;
+    fake->forceCloseFailure = forceCloseFailure;
+    lastFakeWriter = fake;
+    return fake;
   }
 
  private:
@@ -205,5 +250,99 @@ TEST_F(WavFileOutputTests, retry_after_failure_does_not_clobber_or_leak_error) {
   processor.runPendingTasks();
 
   EXPECT_TRUE(std::filesystem::exists(kOutPath));
+  std::filesystem::remove(kOutPath);
+}
+
+// Regression test for the HIGH review finding on PR #14:
+// recordWriteFailureIfAny() used to call deferRepositoryUpdate()
+// unconditionally on every failing processBlock, so a persistent failure
+// (disk full, WAV 4GB cap) during an offline bounce -- which doesn't pump
+// the message loop between blocks -- could queue hundreds of thousands of
+// callAsync closures before the first one drained. This reproduces the
+// open-succeeds-then-every-write-fails shape via FakeFileWriter and asserts
+// exactly one closure is queued no matter how many blocks fail.
+TEST_F(WavFileOutputTests,
+       many_failed_writes_after_successful_open_queue_a_single_update) {
+  const std::filesystem::path kOutPath =
+      std::filesystem::current_path() / "wav_write_failure_test.wav";
+  std::filesystem::remove(kOutPath);
+
+  FileExport config = fileExportRepository.get();
+  config.setAudioFileFormat(AudioFileFormat::WAV);
+  config.setExportAudio(true);
+  config.setSampleRate(48000);
+  config.setBitDepth(16);
+  config.setAudioCodec(AudioCodec::LPCM);
+  config.setExportFile(kOutPath.string());
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+
+  processor.forceWriteFailure = true;
+  config.setManualExport(true);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();  // Drain the export-start clean-slate reset.
+  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+  ASSERT_NE(processor.lastFakeWriter, nullptr);
+  EXPECT_TRUE(processor.lastFakeWriter->isOpen());
+
+  juce::AudioBuffer<float> buffer(2, 64);
+  buffer.clear();
+  juce::MidiBuffer midi;
+  for (int i = 0; i < 5; ++i) {
+    processor.processBlock(buffer, midi);
+  }
+
+  EXPECT_EQ(processor.lastFakeWriter->writeCallCount, 5);
+  // The fix under test: 5 failing blocks must queue exactly one
+  // deferRepositoryUpdate() closure, not one per block.
+  EXPECT_EQ(processor.pendingTaskCount(), 1u);
+
+  processor.runPendingTasks();
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kFileWriteFailed);
+
+  config = fileExportRepository.get();
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+  std::filesystem::remove(kOutPath);
+}
+
+// Companion regression test covering the sibling untested branch flagged in
+// the same review: a close() failure after a successful open and successful
+// writes must still be recorded as kFileWriteFailed.
+TEST_F(WavFileOutputTests, close_failure_after_successful_open_is_recorded) {
+  const std::filesystem::path kOutPath =
+      std::filesystem::current_path() / "wav_close_failure_test.wav";
+  std::filesystem::remove(kOutPath);
+
+  FileExport config = fileExportRepository.get();
+  config.setAudioFileFormat(AudioFileFormat::WAV);
+  config.setExportAudio(true);
+  config.setSampleRate(48000);
+  config.setBitDepth(16);
+  config.setAudioCodec(AudioCodec::LPCM);
+  config.setExportFile(kOutPath.string());
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+
+  processor.forceCloseFailure = true;
+  config.setManualExport(true);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+
+  juce::AudioBuffer<float> buffer(2, 64);
+  buffer.clear();
+  juce::MidiBuffer midi;
+  processor.processBlock(buffer, midi);  // A successful write.
+
+  config = fileExportRepository.get();
+  config.setManualExport(false);
+  fileExportRepository.update(config);
+  processor.runPendingTasks();
+
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kFileWriteFailed);
   std::filesystem::remove(kOutPath);
 }


### PR DESCRIPTION
## Summary

Extends the existing `ExportError` classification/banner mechanism to the
per-audio-element `AudioElementFileWriter`/`FileWriter` WAV writers, which
previously had no error channel at all -- `write()`/`close()` returned `void`
and open failures were never checked. Covers:

- The per-element WAV writer path under `FileOutputProcessor` (open/write/close)
  and its Premiere Pro override's write loop.
- The separate direct-WAV export path in `WavFileOutputProcessor`
  (open/write/close), which had an identical gap.
- A latent memory leak in `FileWriter`'s constructor (JUCE's `createWriterFor`
  does not delete the passed-in stream on failure) and an uninitialized
  `framesWritten` member, both fixed as part of touching this exact code.

`classifyWriteFailure` (the write-probe helper that distinguishes
permission-denied from other write failures) was extracted from
`FileOutputProcessor` into a shared `WriteFailureClassifier.h/.cpp` free
function so `WavFileOutputProcessor` can reuse it without inheriting from
`FileOutputProcessor`.

### A deeper issue found and fixed along the way

`WavFileOutputProcessor` registers itself as a `juce::ValueTree::Listener` on
the same `FileExportRepository` it needs to write status into. Writing to that
repository synchronously from a method reachable via its own listener callback
chain has two independent hazards:

1. **Reentrant-lock deadlock** -- `setNonRealtime()` holds a non-reentrant
   `juce::SpinLock`; a synchronous repository update from inside it re-enters
   `setNonRealtime()` via the listener and hangs forever.
2. **Stale-snapshot clobbering** -- the real export button handler does
   `config = repo.get(); config.setManualExport(!...); repo.update(config)`.
   Since `manualExport` is declared before `exportError`, and
   `juce::ValueTree::copyPropertiesFrom` applies properties in that
   declaration order while firing listener callbacks synchronously mid-loop,
   the caller's own stale `exportError` snapshot gets reapplied moments after
   a nested listener write, silently swallowing it. This reproduces
   deterministically, not as a rare race.

Both are fixed by deferring every `WavFileOutputProcessor` repository write via
`juce::MessageManager::callAsync`, so the write always runs after the entire
triggering call stack has unwound.

## Test plan

- `common/processors/tests/FileOutputProcessor_test.cpp`: two new tests -- a
  per-element open failure (element name containing a path separator, forcing
  only that writer's derived filename into a non-existent subdirectory)
  asserting `ExportError::kFileWriteFailed` while the IAMF file still
  succeeds; a happy-path regression guard.
- `common/processors/tests/WavFileOutputProcessor_test.cpp` (new): a deadlock
  regression test (open failure via the `ManualExport` toggle, mirroring the
  production listener path), a happy-path guard, and a retry-after-failure
  test that reproduces the exact read-modify-write pattern across a failed
  attempt followed by a successful retry.
- Full `ctest` passes serially in a from-scratch build.