### PR TITLE
feat(export): warn when muxed video is longer than the exported audio

### DIFF
--- a/common/components/src/ExportErrorBanner.h
+++ b/common/components/src/ExportErrorBanner.h
@@ -24,10 +24,8 @@
 #include "data_repository/implementation/FileExportRepository.h"
 #include "data_structures/src/FileExport.h"
 
-// Dismissible warning banner that surfaces why the most recent export attempt
-// failed -- or, when it otherwise succeeded, that the muxed audio and video
-// don't run the same length (in either direction) -- reusing
-// WarningBannerBase's chrome. Unlike DAWWarningBanner, this banner starts
+// Dismissible warning banner that surfaces failures or warnings
+// that occur during file export. Unlike DAWWarningBanner, this banner starts
 // hidden and only shows on a fresh transition into an error state (see
 // shouldShowOnTransition) so a dismissal is not immediately undone by the
 // same still-set error value persisting in the repository.

--- a/common/components/src/ExportErrorBanner.h
+++ b/common/components/src/ExportErrorBanner.h
@@ -25,12 +25,12 @@
 #include "data_structures/src/FileExport.h"
 
 // Dismissible warning banner that surfaces why the most recent export attempt
-// failed -- or, when it otherwise succeeded, that the muxed video is longer
-// than the exported audio -- reusing WarningBannerBase's chrome. Unlike
-// DAWWarningBanner, this banner starts hidden and only shows on a fresh
-// transition into an error state (see shouldShowOnTransition) so a dismissal
-// is not immediately undone by the same still-set error value persisting in
-// the repository.
+// failed -- or, when it otherwise succeeded, that the muxed audio and video
+// don't run the same length (in either direction) -- reusing
+// WarningBannerBase's chrome. Unlike DAWWarningBanner, this banner starts
+// hidden and only shows on a fresh transition into an error state (see
+// shouldShowOnTransition) so a dismissal is not immediately undone by the
+// same still-set error value persisting in the repository.
 class ExportErrorBanner : public WarningBannerBase,
                           public juce::ValueTree::Listener {
  public:
@@ -112,6 +112,9 @@ class ExportErrorBanner : public WarningBannerBase,
                "video failed. Check the video source and output folder.";
       case kVideoLongerThanAudio:
         return "The video is longer than the exported audio. The file was "
+               "exported, but the audio and video lengths do not match.";
+      case kAudioLongerThanVideo:
+        return "The exported audio is longer than the video. The file was "
                "exported, but the audio and video lengths do not match.";
       default:
         return messageForError(kFileWriteFailed);

--- a/common/components/src/ExportErrorBanner.h
+++ b/common/components/src/ExportErrorBanner.h
@@ -24,11 +24,13 @@
 #include "data_repository/implementation/FileExportRepository.h"
 #include "data_structures/src/FileExport.h"
 
-// Dismissible warning banner that surfaces the reason the most recent export
-// attempt failed, reusing WarningBannerBase's chrome. Unlike DAWWarningBanner,
-// this banner starts hidden and only shows on a fresh transition into an
-// error state (see shouldShowOnTransition) so a dismissal is not immediately
-// undone by the same still-set error value persisting in the repository.
+// Dismissible warning banner that surfaces either why the most recent export
+// attempt failed, or -- when it otherwise succeeded -- that the muxed video
+// is longer than the exported audio, reusing WarningBannerBase's chrome.
+// Unlike DAWWarningBanner, this banner starts hidden and only shows on a
+// fresh transition into a warning state (see shouldShowWarning) so a
+// dismissal is not immediately undone by the same still-set state persisting
+// in the repository.
 class ExportErrorBanner : public WarningBannerBase,
                           public juce::ValueTree::Listener {
  public:
@@ -36,16 +38,18 @@ class ExportErrorBanner : public WarningBannerBase,
       : repository_(repository) {
     if (repository_) {
       repository_->registerListener(this);
-      previousError_ = repository_->get().getExportError();
+      const FileExport current = repository_->get();
+      previousError_ = current.getExportError();
+      previousMismatch_ = current.getVideoLongerThanAudio();
     }
-    // Seed visibility from whatever error state is already recorded (e.g.
+    // Seed visibility from whatever warning state is already recorded (e.g.
     // the editor was recreated -- some hosts do this on window close/reopen
     // -- while a prior export's failure is still on record and no fresh
     // export has run since). Without this, a banner constructed after an
     // unresolved failure would stay hidden until the NEXT export attempt,
     // silently missing the one that already happened -- the exact bug this
     // feature exists to fix.
-    setVisible(previousError_ != kNoError);
+    setVisible(isWarningState(previousError_, previousMismatch_));
   }
 
   ~ExportErrorBanner() override {
@@ -56,9 +60,13 @@ class ExportErrorBanner : public WarningBannerBase,
                                 const juce::Identifier& property) override {
     if (!repository_ || tree.getType() != repository_->getTree().getType())
       return;
-    if (property != FileExport::kExportError) return;
+    if (property != FileExport::kExportError &&
+        property != FileExport::kVideoLongerThanAudio)
+      return;
 
-    const ExportError current = repository_->get().getExportError();
+    const FileExport current = repository_->get();
+    const ExportError currentError = current.getExportError();
+    const bool currentMismatch = current.getVideoLongerThanAudio();
 
     // This listener can fire off the message thread: FileOutputProcessor
     // updates the repository from setNonRealtime(), which JUCE hosts may
@@ -71,15 +79,17 @@ class ExportErrorBanner : public WarningBannerBase,
     // constructing a fresh SafePointer<ExportErrorBanner>(this) on this
     // thread would be, which touches Component's WeakReference::Master and
     // is only safe on the message thread.
-    juce::MessageManager::callAsync([weakSelf = weakSelf_, current] {
+    juce::MessageManager::callAsync([weakSelf = weakSelf_, currentError,
+                                     currentMismatch] {
       if (!weakSelf) return;
-      const bool shouldShow =
-          shouldShowOnTransition(weakSelf->previousError_, current);
-      const bool shouldHide = shouldHideOnTransition(current);
-      weakSelf->previousError_ = current;
-      if (shouldShow) {
+      const bool kWasWarning =
+          isWarningState(weakSelf->previousError_, weakSelf->previousMismatch_);
+      const bool kIsWarning = isWarningState(currentError, currentMismatch);
+      weakSelf->previousError_ = currentError;
+      weakSelf->previousMismatch_ = currentMismatch;
+      if (shouldShowWarning(kWasWarning, kIsWarning)) {
         weakSelf->setVisible(true);
-      } else if (shouldHide) {
+      } else if (shouldHideWarning(kIsWarning)) {
         weakSelf->setVisible(false);
       }
       if (weakSelf->onVisibilityChanged) weakSelf->onVisibilityChanged();
@@ -125,10 +135,43 @@ class ExportErrorBanner : public WarningBannerBase,
     return current == kNoError;
   }
 
+  // Maps the combined export state to user-facing text. A hard failure
+  // always wins over the duration-mismatch warning: muxing didn't get far
+  // enough for "video is longer than audio" to be a meaningful thing to say
+  // alongside it.
+  static juce::String messageForState(ExportError error,
+                                      bool videoLongerThanAudio) {
+    if (error != kNoError) return messageForError(error);
+    if (videoLongerThanAudio) {
+      return "The video is longer than the exported audio. The file was "
+             "exported, but the audio and video lengths do not match.";
+    }
+    return "";
+  }
+
+  // True whenever there is something worth showing the user: a hard export
+  // failure, or -- mux having otherwise succeeded -- a video/audio duration
+  // mismatch.
+  static bool isWarningState(ExportError error, bool videoLongerThanAudio) {
+    return error != kNoError || videoLongerThanAudio;
+  }
+
+  // Same "only re-appear on a fresh transition" rule as
+  // shouldShowOnTransition/shouldHideOnTransition above, generalized to the
+  // combined (error OR mismatch) warning state so the banner has one
+  // transition rule regardless of which condition triggered it.
+  static bool shouldShowWarning(bool previousWarning, bool currentWarning) {
+    return !previousWarning && currentWarning;
+  }
+
+  static bool shouldHideWarning(bool currentWarning) { return !currentWarning; }
+
  protected:
   juce::String getMessageText() const override {
-    return messageForError(repository_ ? repository_->get().getExportError()
-                                       : kNoError);
+    if (!repository_) return messageForState(kNoError, false);
+    const FileExport current = repository_->get();
+    return messageForState(current.getExportError(),
+                           current.getVideoLongerThanAudio());
   }
 
   // Transient dismiss: no repository write, unlike DAWWarningBanner's
@@ -139,6 +182,7 @@ class ExportErrorBanner : public WarningBannerBase,
  private:
   FileExportRepository* repository_;
   ExportError previousError_ = kNoError;
+  bool previousMismatch_ = false;
   // Constructed once on the message thread (this banner is always built as
   // part of editor construction) and only ever copied afterward -- see the
   // comment in valueTreePropertyChanged for why that distinction matters.

--- a/common/components/src/ExportErrorBanner.h
+++ b/common/components/src/ExportErrorBanner.h
@@ -110,10 +110,12 @@ class ExportErrorBanner : public WarningBannerBase,
                "video failed. Check the video source and output folder.";
       case kVideoLongerThanAudio:
         return "The video is longer than the exported audio. The file was "
-               "exported, but the audio will end before the video during playback.";
+               "exported, but the audio will end before the video during "
+               "playback.";
       case kAudioLongerThanVideo:
         return "The exported audio is longer than the video. The file was "
-               "exported, but the audio has been shortened to fit the video file.";
+               "exported, but the audio has been shortened to fit the video "
+               "file.";
       default:
         return messageForError(kFileWriteFailed);
     }

--- a/common/components/src/ExportErrorBanner.h
+++ b/common/components/src/ExportErrorBanner.h
@@ -110,10 +110,10 @@ class ExportErrorBanner : public WarningBannerBase,
                "video failed. Check the video source and output folder.";
       case kVideoLongerThanAudio:
         return "The video is longer than the exported audio. The file was "
-               "exported, but the audio and video lengths do not match.";
+               "exported, but the audio will end before the video during playback.";
       case kAudioLongerThanVideo:
         return "The exported audio is longer than the video. The file was "
-               "exported, but the audio and video lengths do not match.";
+               "exported, but the audio has been shortened to fit the video file.";
       default:
         return messageForError(kFileWriteFailed);
     }

--- a/common/components/src/ExportErrorBanner.h
+++ b/common/components/src/ExportErrorBanner.h
@@ -24,13 +24,13 @@
 #include "data_repository/implementation/FileExportRepository.h"
 #include "data_structures/src/FileExport.h"
 
-// Dismissible warning banner that surfaces either why the most recent export
-// attempt failed, or -- when it otherwise succeeded -- that the muxed video
-// is longer than the exported audio, reusing WarningBannerBase's chrome.
-// Unlike DAWWarningBanner, this banner starts hidden and only shows on a
-// fresh transition into a warning state (see shouldShowWarning) so a
-// dismissal is not immediately undone by the same still-set state persisting
-// in the repository.
+// Dismissible warning banner that surfaces why the most recent export attempt
+// failed -- or, when it otherwise succeeded, that the muxed video is longer
+// than the exported audio -- reusing WarningBannerBase's chrome. Unlike
+// DAWWarningBanner, this banner starts hidden and only shows on a fresh
+// transition into an error state (see shouldShowOnTransition) so a dismissal
+// is not immediately undone by the same still-set error value persisting in
+// the repository.
 class ExportErrorBanner : public WarningBannerBase,
                           public juce::ValueTree::Listener {
  public:
@@ -38,18 +38,16 @@ class ExportErrorBanner : public WarningBannerBase,
       : repository_(repository) {
     if (repository_) {
       repository_->registerListener(this);
-      const FileExport current = repository_->get();
-      previousError_ = current.getExportError();
-      previousMismatch_ = current.getVideoLongerThanAudio();
+      previousError_ = repository_->get().getExportError();
     }
-    // Seed visibility from whatever warning state is already recorded (e.g.
+    // Seed visibility from whatever error state is already recorded (e.g.
     // the editor was recreated -- some hosts do this on window close/reopen
     // -- while a prior export's failure is still on record and no fresh
     // export has run since). Without this, a banner constructed after an
     // unresolved failure would stay hidden until the NEXT export attempt,
     // silently missing the one that already happened -- the exact bug this
     // feature exists to fix.
-    setVisible(isWarningState(previousError_, previousMismatch_));
+    setVisible(previousError_ != kNoError);
   }
 
   ~ExportErrorBanner() override {
@@ -60,13 +58,9 @@ class ExportErrorBanner : public WarningBannerBase,
                                 const juce::Identifier& property) override {
     if (!repository_ || tree.getType() != repository_->getTree().getType())
       return;
-    if (property != FileExport::kExportError &&
-        property != FileExport::kVideoLongerThanAudio)
-      return;
+    if (property != FileExport::kExportError) return;
 
-    const FileExport current = repository_->get();
-    const ExportError currentError = current.getExportError();
-    const bool currentMismatch = current.getVideoLongerThanAudio();
+    const ExportError current = repository_->get().getExportError();
 
     // This listener can fire off the message thread: FileOutputProcessor
     // updates the repository from setNonRealtime(), which JUCE hosts may
@@ -79,17 +73,15 @@ class ExportErrorBanner : public WarningBannerBase,
     // constructing a fresh SafePointer<ExportErrorBanner>(this) on this
     // thread would be, which touches Component's WeakReference::Master and
     // is only safe on the message thread.
-    juce::MessageManager::callAsync([weakSelf = weakSelf_, currentError,
-                                     currentMismatch] {
+    juce::MessageManager::callAsync([weakSelf = weakSelf_, current] {
       if (!weakSelf) return;
-      const bool kWasWarning =
-          isWarningState(weakSelf->previousError_, weakSelf->previousMismatch_);
-      const bool kIsWarning = isWarningState(currentError, currentMismatch);
-      weakSelf->previousError_ = currentError;
-      weakSelf->previousMismatch_ = currentMismatch;
-      if (shouldShowWarning(kWasWarning, kIsWarning)) {
+      const bool shouldShow =
+          shouldShowOnTransition(weakSelf->previousError_, current);
+      const bool shouldHide = shouldHideOnTransition(current);
+      weakSelf->previousError_ = current;
+      if (shouldShow) {
         weakSelf->setVisible(true);
-      } else if (shouldHideWarning(kIsWarning)) {
+      } else if (shouldHide) {
         weakSelf->setVisible(false);
       }
       if (weakSelf->onVisibilityChanged) weakSelf->onVisibilityChanged();
@@ -118,6 +110,9 @@ class ExportErrorBanner : public WarningBannerBase,
       case kMuxFailed:
         return "Export failed: audio was exported, but combining it with the "
                "video failed. Check the video source and output folder.";
+      case kVideoLongerThanAudio:
+        return "The video is longer than the exported audio. The file was "
+               "exported, but the audio and video lengths do not match.";
       default:
         return messageForError(kFileWriteFailed);
     }
@@ -135,43 +130,10 @@ class ExportErrorBanner : public WarningBannerBase,
     return current == kNoError;
   }
 
-  // Maps the combined export state to user-facing text. A hard failure
-  // always wins over the duration-mismatch warning: muxing didn't get far
-  // enough for "video is longer than audio" to be a meaningful thing to say
-  // alongside it.
-  static juce::String messageForState(ExportError error,
-                                      bool videoLongerThanAudio) {
-    if (error != kNoError) return messageForError(error);
-    if (videoLongerThanAudio) {
-      return "The video is longer than the exported audio. The file was "
-             "exported, but the audio and video lengths do not match.";
-    }
-    return "";
-  }
-
-  // True whenever there is something worth showing the user: a hard export
-  // failure, or -- mux having otherwise succeeded -- a video/audio duration
-  // mismatch.
-  static bool isWarningState(ExportError error, bool videoLongerThanAudio) {
-    return error != kNoError || videoLongerThanAudio;
-  }
-
-  // Same "only re-appear on a fresh transition" rule as
-  // shouldShowOnTransition/shouldHideOnTransition above, generalized to the
-  // combined (error OR mismatch) warning state so the banner has one
-  // transition rule regardless of which condition triggered it.
-  static bool shouldShowWarning(bool previousWarning, bool currentWarning) {
-    return !previousWarning && currentWarning;
-  }
-
-  static bool shouldHideWarning(bool currentWarning) { return !currentWarning; }
-
  protected:
   juce::String getMessageText() const override {
-    if (!repository_) return messageForState(kNoError, false);
-    const FileExport current = repository_->get();
-    return messageForState(current.getExportError(),
-                           current.getVideoLongerThanAudio());
+    return messageForError(repository_ ? repository_->get().getExportError()
+                                       : kNoError);
   }
 
   // Transient dismiss: no repository write, unlike DAWWarningBanner's
@@ -182,7 +144,6 @@ class ExportErrorBanner : public WarningBannerBase,
  private:
   FileExportRepository* repository_;
   ExportError previousError_ = kNoError;
-  bool previousMismatch_ = false;
   // Constructed once on the message thread (this banner is always built as
   // part of editor construction) and only ever copied afterward -- see the
   // comment in valueTreePropertyChanged for why that distinction matters.

--- a/common/components/tests/ExportErrorBanner_test.cpp
+++ b/common/components/tests/ExportErrorBanner_test.cpp
@@ -39,13 +39,20 @@ TEST(test_export_error_banner, messageForErrorNonEmptyExceptNoError) {
   EXPECT_TRUE(ExportErrorBanner::messageForError(kMuxFailed).isNotEmpty());
   EXPECT_TRUE(
       ExportErrorBanner::messageForError(kVideoLongerThanAudio).isNotEmpty());
+  EXPECT_TRUE(
+      ExportErrorBanner::messageForError(kAudioLongerThanVideo).isNotEmpty());
 }
 
-// Issue #38: the mismatch message must name the mismatch, not read like a
-// generic failure -- it's a warning, the export itself still succeeded.
-TEST(test_export_error_banner, videoLongerThanAudioNamesTheMismatch) {
+// Each duration-mismatch message must name its own direction, not read like a
+// generic failure -- it's a warning, the export itself still succeeded -- and
+// the two directions must not share wording.
+TEST(test_export_error_banner, durationMismatchMessagesNameTheDirection) {
   EXPECT_TRUE(ExportErrorBanner::messageForError(kVideoLongerThanAudio)
                   .containsIgnoreCase("longer"));
+  EXPECT_TRUE(ExportErrorBanner::messageForError(kAudioLongerThanVideo)
+                  .containsIgnoreCase("longer"));
+  EXPECT_NE(ExportErrorBanner::messageForError(kVideoLongerThanAudio),
+            ExportErrorBanner::messageForError(kAudioLongerThanVideo));
 }
 
 // Permission-denied must not share generic write-failure wording -- this is
@@ -66,6 +73,8 @@ TEST(test_export_error_banner, shouldShowOnTransition) {
       ExportErrorBanner::shouldShowOnTransition(kNoError, kFileWriteFailed));
   EXPECT_TRUE(ExportErrorBanner::shouldShowOnTransition(kNoError,
                                                         kVideoLongerThanAudio));
+  EXPECT_TRUE(ExportErrorBanner::shouldShowOnTransition(kNoError,
+                                                        kAudioLongerThanVideo));
   EXPECT_FALSE(ExportErrorBanner::shouldShowOnTransition(kFileWriteFailed,
                                                          kFileWriteFailed));
   EXPECT_FALSE(ExportErrorBanner::shouldShowOnTransition(kNoError, kNoError));

--- a/common/components/tests/ExportErrorBanner_test.cpp
+++ b/common/components/tests/ExportErrorBanner_test.cpp
@@ -37,6 +37,15 @@ TEST(test_export_error_banner, messageForErrorNonEmptyExceptNoError) {
   EXPECT_TRUE(
       ExportErrorBanner::messageForError(kPermissionDenied).isNotEmpty());
   EXPECT_TRUE(ExportErrorBanner::messageForError(kMuxFailed).isNotEmpty());
+  EXPECT_TRUE(
+      ExportErrorBanner::messageForError(kVideoLongerThanAudio).isNotEmpty());
+}
+
+// Issue #38: the mismatch message must name the mismatch, not read like a
+// generic failure -- it's a warning, the export itself still succeeded.
+TEST(test_export_error_banner, videoLongerThanAudioNamesTheMismatch) {
+  EXPECT_TRUE(ExportErrorBanner::messageForError(kVideoLongerThanAudio)
+                  .containsIgnoreCase("longer"));
 }
 
 // Permission-denied must not share generic write-failure wording -- this is
@@ -55,6 +64,8 @@ TEST(test_export_error_banner, permissionDeniedHasDistinctWording) {
 TEST(test_export_error_banner, shouldShowOnTransition) {
   EXPECT_TRUE(
       ExportErrorBanner::shouldShowOnTransition(kNoError, kFileWriteFailed));
+  EXPECT_TRUE(ExportErrorBanner::shouldShowOnTransition(kNoError,
+                                                        kVideoLongerThanAudio));
   EXPECT_FALSE(ExportErrorBanner::shouldShowOnTransition(kFileWriteFailed,
                                                          kFileWriteFailed));
   EXPECT_FALSE(ExportErrorBanner::shouldShowOnTransition(kNoError, kNoError));
@@ -67,39 +78,4 @@ TEST(test_export_error_banner, shouldHideOnTransition) {
   EXPECT_TRUE(ExportErrorBanner::shouldHideOnTransition(kNoError));
   EXPECT_FALSE(ExportErrorBanner::shouldHideOnTransition(kFileWriteFailed));
   EXPECT_FALSE(ExportErrorBanner::shouldHideOnTransition(kPermissionDenied));
-}
-
-// A hard error, the mismatch flag, or both together should all count as a
-// warning state; only kNoError with no mismatch should not.
-TEST(test_export_error_banner, isWarningState) {
-  EXPECT_FALSE(ExportErrorBanner::isWarningState(kNoError, false));
-  EXPECT_TRUE(ExportErrorBanner::isWarningState(kNoError, true));
-  EXPECT_TRUE(ExportErrorBanner::isWarningState(kMuxFailed, false));
-  EXPECT_TRUE(ExportErrorBanner::isWarningState(kMuxFailed, true));
-}
-
-// The mismatch message must name the mismatch (not a generic failure) and
-// must be empty when there is nothing to warn about; a real error always
-// takes priority over the mismatch wording.
-TEST(test_export_error_banner, messageForStatePrioritizesErrorOverMismatch) {
-  EXPECT_TRUE(ExportErrorBanner::messageForState(kNoError, false).isEmpty());
-  EXPECT_TRUE(ExportErrorBanner::messageForState(kNoError, true)
-                  .containsIgnoreCase("longer"));
-  EXPECT_EQ(ExportErrorBanner::messageForState(kMuxFailed, true),
-            ExportErrorBanner::messageForError(kMuxFailed));
-}
-
-// Same "only re-appear on a fresh transition" rule as shouldShowOnTransition,
-// generalized to the combined warning state used once either an error or a
-// mismatch can trigger the banner.
-TEST(test_export_error_banner, shouldShowWarning) {
-  EXPECT_TRUE(ExportErrorBanner::shouldShowWarning(false, true));
-  EXPECT_FALSE(ExportErrorBanner::shouldShowWarning(true, true));
-  EXPECT_FALSE(ExportErrorBanner::shouldShowWarning(false, false));
-}
-
-// The banner should hide exactly when the combined warning state clears.
-TEST(test_export_error_banner, shouldHideWarning) {
-  EXPECT_TRUE(ExportErrorBanner::shouldHideWarning(false));
-  EXPECT_FALSE(ExportErrorBanner::shouldHideWarning(true));
 }

--- a/common/components/tests/ExportErrorBanner_test.cpp
+++ b/common/components/tests/ExportErrorBanner_test.cpp
@@ -68,3 +68,38 @@ TEST(test_export_error_banner, shouldHideOnTransition) {
   EXPECT_FALSE(ExportErrorBanner::shouldHideOnTransition(kFileWriteFailed));
   EXPECT_FALSE(ExportErrorBanner::shouldHideOnTransition(kPermissionDenied));
 }
+
+// A hard error, the mismatch flag, or both together should all count as a
+// warning state; only kNoError with no mismatch should not.
+TEST(test_export_error_banner, isWarningState) {
+  EXPECT_FALSE(ExportErrorBanner::isWarningState(kNoError, false));
+  EXPECT_TRUE(ExportErrorBanner::isWarningState(kNoError, true));
+  EXPECT_TRUE(ExportErrorBanner::isWarningState(kMuxFailed, false));
+  EXPECT_TRUE(ExportErrorBanner::isWarningState(kMuxFailed, true));
+}
+
+// The mismatch message must name the mismatch (not a generic failure) and
+// must be empty when there is nothing to warn about; a real error always
+// takes priority over the mismatch wording.
+TEST(test_export_error_banner, messageForStatePrioritizesErrorOverMismatch) {
+  EXPECT_TRUE(ExportErrorBanner::messageForState(kNoError, false).isEmpty());
+  EXPECT_TRUE(ExportErrorBanner::messageForState(kNoError, true)
+                  .containsIgnoreCase("longer"));
+  EXPECT_EQ(ExportErrorBanner::messageForState(kMuxFailed, true),
+            ExportErrorBanner::messageForError(kMuxFailed));
+}
+
+// Same "only re-appear on a fresh transition" rule as shouldShowOnTransition,
+// generalized to the combined warning state used once either an error or a
+// mismatch can trigger the banner.
+TEST(test_export_error_banner, shouldShowWarning) {
+  EXPECT_TRUE(ExportErrorBanner::shouldShowWarning(false, true));
+  EXPECT_FALSE(ExportErrorBanner::shouldShowWarning(true, true));
+  EXPECT_FALSE(ExportErrorBanner::shouldShowWarning(false, false));
+}
+
+// The banner should hide exactly when the combined warning state clears.
+TEST(test_export_error_banner, shouldHideWarning) {
+  EXPECT_TRUE(ExportErrorBanner::shouldHideWarning(false));
+  EXPECT_FALSE(ExportErrorBanner::shouldHideWarning(true));
+}

--- a/common/data_structures/src/FileExport.cpp
+++ b/common/data_structures/src/FileExport.cpp
@@ -39,7 +39,8 @@ FileExport::FileExport()
       profile_(FileProfile::BASE),
       exportCompleted_(true),
       securityBookmark_(""),
-      exportError_(kNoError) {}
+      exportError_(kNoError),
+      videoLongerThanAudio_(false) {}
 
 FileExport::FileExport(long startSampleIdx, long endSampleIdx,
                        juce::String exportFile, juce::String exportFolder,
@@ -73,7 +74,8 @@ FileExport::FileExport(long startSampleIdx, long endSampleIdx,
       sample_tally_(0),
       exportCompleted_(exportCompleted),
       securityBookmark_(securityBookmark),
-      exportError_(kNoError) {}
+      exportError_(kNoError),
+      videoLongerThanAudio_(false) {}
 
 FileExport FileExport::fromTree(const juce::ValueTree tree) {
   FileExport result(
@@ -87,6 +89,7 @@ FileExport FileExport::fromTree(const juce::ValueTree tree) {
       tree[kOpusTotalBitrate], tree[kLPCMSampleSize], tree[kExportCompleted],
       tree[kSecurityBookmark]);
   result.setExportError((ExportError)(int)tree[kExportError]);
+  result.setVideoLongerThanAudio((bool)tree[kVideoLongerThanAudio]);
   return result;
 }
 
@@ -113,7 +116,8 @@ juce::ValueTree FileExport::toValueTree() const {
            {kSampleTally, static_cast<juce::int64>(sample_tally_)},
            {kExportCompleted, exportCompleted_},
            {kSecurityBookmark, securityBookmark_},
-           {kExportError, static_cast<int>(exportError_)}}};
+           {kExportError, static_cast<int>(exportError_)},
+           {kVideoLongerThanAudio, videoLongerThanAudio_}}};
 }
 
 juce::String FileExport::expandTildePath(const juce::String& path) {

--- a/common/data_structures/src/FileExport.cpp
+++ b/common/data_structures/src/FileExport.cpp
@@ -39,8 +39,7 @@ FileExport::FileExport()
       profile_(FileProfile::BASE),
       exportCompleted_(true),
       securityBookmark_(""),
-      exportError_(kNoError),
-      videoLongerThanAudio_(false) {}
+      exportError_(kNoError) {}
 
 FileExport::FileExport(long startSampleIdx, long endSampleIdx,
                        juce::String exportFile, juce::String exportFolder,
@@ -74,8 +73,7 @@ FileExport::FileExport(long startSampleIdx, long endSampleIdx,
       sample_tally_(0),
       exportCompleted_(exportCompleted),
       securityBookmark_(securityBookmark),
-      exportError_(kNoError),
-      videoLongerThanAudio_(false) {}
+      exportError_(kNoError) {}
 
 FileExport FileExport::fromTree(const juce::ValueTree tree) {
   FileExport result(
@@ -89,7 +87,6 @@ FileExport FileExport::fromTree(const juce::ValueTree tree) {
       tree[kOpusTotalBitrate], tree[kLPCMSampleSize], tree[kExportCompleted],
       tree[kSecurityBookmark]);
   result.setExportError((ExportError)(int)tree[kExportError]);
-  result.setVideoLongerThanAudio((bool)tree[kVideoLongerThanAudio]);
   return result;
 }
 
@@ -116,8 +113,7 @@ juce::ValueTree FileExport::toValueTree() const {
            {kSampleTally, static_cast<juce::int64>(sample_tally_)},
            {kExportCompleted, exportCompleted_},
            {kSecurityBookmark, securityBookmark_},
-           {kExportError, static_cast<int>(exportError_)},
-           {kVideoLongerThanAudio, videoLongerThanAudio_}}};
+           {kExportError, static_cast<int>(exportError_)}}};
 }
 
 juce::String FileExport::expandTildePath(const juce::String& path) {

--- a/common/data_structures/src/FileExport.cpp
+++ b/common/data_structures/src/FileExport.cpp
@@ -41,7 +41,7 @@ FileExport::FileExport()
       securityBookmark_(""),
       exportError_(kNoError) {}
 
-FileExport::FileExport(long startSampleIdx, long endSampleIdx,
+FileExport::FileExport(juce::int64 startSampleIdx, juce::int64 endSampleIdx,
                        juce::String exportFile, juce::String exportFolder,
                        AudioFileFormat audioFileFormat, AudioCodec audioCodec,
                        int bitDepth, int sampleRate, bool exportAudioElements,
@@ -92,8 +92,8 @@ FileExport FileExport::fromTree(const juce::ValueTree tree) {
 
 juce::ValueTree FileExport::toValueTree() const {
   return {kTreeType,
-          {{kStartSampleIdx, static_cast<juce::int64>(startSampleIdx_)},
-           {kEndSampleIdx, static_cast<juce::int64>(endSampleIdx_)},
+          {{kStartSampleIdx, startSampleIdx_},
+           {kEndSampleIdx, endSampleIdx_},
            {kExportFile, exportFile_},
            {kExportFolder, exportFolder_},
            {kAudioFileFormat, audioFileFormat_},
@@ -110,7 +110,7 @@ juce::ValueTree FileExport::toValueTree() const {
            {kFlacCompressionLevel, flac_compression_level_},
            {kOpusTotalBitrate, opus_total_bitrate_},
            {kLPCMSampleSize, lpcm_sample_size_},
-           {kSampleTally, static_cast<juce::int64>(sample_tally_)},
+           {kSampleTally, sample_tally_},
            {kExportCompleted, exportCompleted_},
            {kSecurityBookmark, securityBookmark_},
            {kExportError, static_cast<int>(exportError_)}}};

--- a/common/data_structures/src/FileExport.h
+++ b/common/data_structures/src/FileExport.h
@@ -24,16 +24,21 @@ enum AudioFileFormat { IAMF = 0, WAV = 1, ADM = 2 };
 
 enum AudioCodec { LPCM = 0, FLAC = 1, OPUS = 2 };
 
-// Classifies why an export failed (or kNoError if it did not). Set by
-// FileOutputProcessor as it progresses through an export so failures
-// propagate out of the audio processor into the data layer instead of only
-// being logged.
+// Classifies why an export failed, or -- for kVideoLongerThanAudio -- warns
+// about it without it having failed (or kNoError if there is nothing to
+// report). Set by FileOutputProcessor as it progresses through an export so
+// failures/warnings propagate out of the audio processor into the data layer
+// instead of only being logged. Only one value is ever recorded per export;
+// a hard failure always takes priority over kVideoLongerThanAudio since it is
+// the more critical thing to surface (see the kNoError guards in
+// FileOutputProcessor).
 enum ExportError {
   kNoError = 0,
   kInvalidExportPath = 1,
   kFileWriteFailed = 2,
   kPermissionDenied = 3,
-  kMuxFailed = 4
+  kMuxFailed = 4,
+  kVideoLongerThanAudio = 5
 };
 
 // Using a macro here to help minimize the amount of code
@@ -147,9 +152,4 @@ class FileExport final : public RepositoryItemBase {
   EXPORT_VALUE(bool, exportCompleted, ExportCompleted);
   EXPORT_VALUE(juce::String, securityBookmark, SecurityBookmark);
   EXPORT_VALUE(ExportError, exportError, ExportError);
-  // Set when a video/audio mux completed but the video is longer than the
-  // exported audio (kIAMFExported and getExportVideo() were both true).
-  // Distinct from ExportError -- the export itself succeeded, this is a
-  // warning about the two inputs' lengths, not a failure to write output.
-  EXPORT_VALUE(bool, videoLongerThanAudio, VideoLongerThanAudio);
 };

--- a/common/data_structures/src/FileExport.h
+++ b/common/data_structures/src/FileExport.h
@@ -109,12 +109,13 @@ class FileProfileHelper {
 class FileExport final : public RepositoryItemBase {
  public:
   FileExport();
-  FileExport(long startSampleIdx, long endSampleIdx, juce::String exportFile,
-             juce::String exportFolder, AudioFileFormat audioFileFormat,
-             AudioCodec audioCodec, int bitDepth, int sampleRate,
-             bool exportAudioElements, bool exportAudio, bool exportVideo,
-             juce::String videoSource, juce::String videoExportFolder,
-             bool manualExport, FileProfile profile, int flac_compression_level,
+  FileExport(juce::int64 startSampleIdx, juce::int64 endSampleIdx,
+             juce::String exportFile, juce::String exportFolder,
+             AudioFileFormat audioFileFormat, AudioCodec audioCodec,
+             int bitDepth, int sampleRate, bool exportAudioElements,
+             bool exportAudio, bool exportVideo, juce::String videoSource,
+             juce::String videoExportFolder, bool manualExport,
+             FileProfile profile, int flac_compression_level,
              int opus_total_bitrate, int lpcm_sample_size, bool exportCompleted,
              juce::String securityBookmark);
 
@@ -133,8 +134,8 @@ class FileExport final : public RepositoryItemBase {
   inline static const juce::Identifier kTreeType{"file_export"};
 
  private:
-  EXPORT_VALUE(long, startSampleIdx, StartSampleIdx);
-  EXPORT_VALUE(long, endSampleIdx, EndSampleIdx);
+  EXPORT_VALUE(juce::int64, startSampleIdx, StartSampleIdx);
+  EXPORT_VALUE(juce::int64, endSampleIdx, EndSampleIdx);
   EXPORT_VALUE(juce::String, exportFile, ExportFile);
   EXPORT_VALUE(juce::String, exportFolder, ExportFolder);
   EXPORT_VALUE(AudioFileFormat, audioFileFormat, AudioFileFormat);
@@ -151,7 +152,7 @@ class FileExport final : public RepositoryItemBase {
   EXPORT_VALUE(int, flac_compression_level, FlacCompressionLevel);
   EXPORT_VALUE(int, opus_total_bitrate, OpusTotalBitrate);
   EXPORT_VALUE(int, lpcm_sample_size, LPCMSampleSize);
-  EXPORT_VALUE(long, sample_tally, SampleTally);
+  EXPORT_VALUE(juce::int64, sample_tally, SampleTally);
   EXPORT_VALUE(bool, exportCompleted, ExportCompleted);
   EXPORT_VALUE(juce::String, securityBookmark, SecurityBookmark);
   EXPORT_VALUE(ExportError, exportError, ExportError);

--- a/common/data_structures/src/FileExport.h
+++ b/common/data_structures/src/FileExport.h
@@ -24,21 +24,20 @@ enum AudioFileFormat { IAMF = 0, WAV = 1, ADM = 2 };
 
 enum AudioCodec { LPCM = 0, FLAC = 1, OPUS = 2 };
 
-// Classifies why an export failed, or -- for kVideoLongerThanAudio -- warns
-// about it without it having failed (or kNoError if there is nothing to
-// report). Set by FileOutputProcessor as it progresses through an export so
+// Classifies why an export failed, or warns about other export conditions.
+// Set by FileOutputProcessor as it progresses through an export so
 // failures/warnings propagate out of the audio processor into the data layer
 // instead of only being logged. Only one value is ever recorded per export;
-// a hard failure always takes priority over kVideoLongerThanAudio since it is
-// the more critical thing to surface (see the kNoError guards in
-// FileOutputProcessor).
+// failures with lower values take precedent over higher values, so the most
+// severe failure is always recorded.
 enum ExportError {
   kNoError = 0,
   kInvalidExportPath = 1,
   kFileWriteFailed = 2,
   kPermissionDenied = 3,
   kMuxFailed = 4,
-  kVideoLongerThanAudio = 5
+  kVideoLongerThanAudio = 5,
+  kAudioLongerThanVideo = 6
 };
 
 // Using a macro here to help minimize the amount of code

--- a/common/data_structures/src/FileExport.h
+++ b/common/data_structures/src/FileExport.h
@@ -25,11 +25,15 @@ enum AudioFileFormat { IAMF = 0, WAV = 1, ADM = 2 };
 enum AudioCodec { LPCM = 0, FLAC = 1, OPUS = 2 };
 
 // Classifies why an export failed, or warns about other export conditions.
-// Set by FileOutputProcessor as it progresses through an export so
-// failures/warnings propagate out of the audio processor into the data layer
-// instead of only being logged. Only one value is ever recorded per export;
-// failures with lower values take precedent over higher values, so the most
-// severe failure is always recorded.
+// Set by FileOutputProcessor via FileExport::recordExportErrorIfUnset() as it
+// progresses through an export, so failures/warnings propagate out of the
+// audio processor into the data layer instead of only being logged. Only the
+// first error/warning recorded during an export is kept -- later
+// recordExportErrorIfUnset() calls are no-ops once any non-kNoError value is
+// set. The values below are ordered to match the sequence these conditions
+// are checked during an export (per-block write failures, then close/mux
+// failures, then the duration-mismatch check), not by comparison of the
+// values themselves.
 enum ExportError {
   kNoError = 0,
   kInvalidExportPath = 1,
@@ -151,4 +155,18 @@ class FileExport final : public RepositoryItemBase {
   EXPORT_VALUE(bool, exportCompleted, ExportCompleted);
   EXPORT_VALUE(juce::String, securityBookmark, SecurityBookmark);
   EXPORT_VALUE(ExportError, exportError, ExportError);
+
+ public:
+  // Records newError only if no error/warning has been recorded yet for this
+  // export -- the first call wins; every subsequent call is a no-op until
+  // the next export resets exportError_ back to kNoError. Returns whether
+  // newError was recorded, so callers can skip an unnecessary repository
+  // update when nothing changed.
+  bool recordExportErrorIfUnset(ExportError newError) {
+    if (exportError_ == kNoError) {
+      exportError_ = newError;
+      return true;
+    }
+    return false;
+  }
 };

--- a/common/data_structures/src/FileExport.h
+++ b/common/data_structures/src/FileExport.h
@@ -147,4 +147,9 @@ class FileExport final : public RepositoryItemBase {
   EXPORT_VALUE(bool, exportCompleted, ExportCompleted);
   EXPORT_VALUE(juce::String, securityBookmark, SecurityBookmark);
   EXPORT_VALUE(ExportError, exportError, ExportError);
+  // Set when a video/audio mux completed but the video is longer than the
+  // exported audio (kIAMFExported and getExportVideo() were both true).
+  // Distinct from ExportError -- the export itself succeeded, this is a
+  // warning about the two inputs' lengths, not a failure to write output.
+  EXPORT_VALUE(bool, videoLongerThanAudio, VideoLongerThanAudio);
 };

--- a/common/data_structures/tests/FileExport_test.cpp
+++ b/common/data_structures/tests/FileExport_test.cpp
@@ -34,3 +34,23 @@ TEST(test_file_export, from_tree_missing_export_audio_elements_defaults_false) {
 
   EXPECT_FALSE(fileExport.getExportAudioElements());
 }
+
+// Regression test: startSampleIdx_/endSampleIdx_ were widened from `long`
+// (32-bit on Windows LLP64) to juce::int64 so a sample index deep into a
+// long session (e.g. past ~12.4 hours at 48kHz) doesn't silently
+// truncate/wrap. Confirm a value past INT32_MAX survives a
+// toValueTree()/fromTree() round-trip -- the same path FileExportRepository
+// uses internally -- fully intact.
+TEST(test_file_export, round_trip_preserves_sample_indices_past_int32_max) {
+  constexpr juce::int64 kBeyondInt32Max = 3'000'000'000LL;  // > 2^31 - 1
+
+  FileExport config;
+  config.setStartSampleIdx(kBeyondInt32Max);
+  config.setEndSampleIdx(kBeyondInt32Max + 1000);
+
+  const juce::ValueTree tree = config.toValueTree();
+  const FileExport roundTripped = FileExport::fromTree(tree);
+
+  EXPECT_EQ(roundTripped.getStartSampleIdx(), kBeyondInt32Max);
+  EXPECT_EQ(roundTripped.getEndSampleIdx(), kBeyondInt32Max + 1000);
+}

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -260,13 +260,15 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
       }
     }
 
-    // Run the mismatch check regardless of whether the mux above succeeded.
-    // Only one of a failed write, a failed mux, or a duration mismatch can be
-    // shown to the user; checkAudioVideoDurationMismatch stays silent if a
-    // more critical failure is already on record via
-    // FileExport::recordExportErrorIfUnset's first-recorded-error-wins
-    // semantics, not via a guard here.
-    checkAudioVideoDurationMismatch();
+    // Only run the mismatch check when the mux above succeeded. If it
+    // failed, kMuxFailed is already on record and the video file was never
+    // opened by muxIAMF() (muxVideo() short-circuits after a failed audio
+    // mux) -- gating here keeps that same invariant instead of having
+    // checkAudioVideoDurationMismatch() open the untrusted user-supplied
+    // video file on a path that previously never touched it.
+    if (kMuxIamfSuccess) {
+      checkAudioVideoDurationMismatch();
+    }
   }
 
   if (!config.getExportAudioElements()) {

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -260,10 +260,12 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
       }
     }
 
-    // Only escalate to the mismatch check if a more critical failure (a
-    // failed write or a failed mux, just above) is not already on record --
-    // only one of these can be shown to the user, and the failure to produce
-    // a correct file is the more important thing to surface.
+    // Run the mismatch check regardless of whether the mux above succeeded.
+    // Only one of a failed write, a failed mux, or a duration mismatch can be
+    // shown to the user; checkAudioVideoDurationMismatch stays silent if a
+    // more critical failure is already on record via
+    // FileExport::recordExportErrorIfUnset's first-recorded-error-wins
+    // semantics, not via a guard here.
     checkAudioVideoDurationMismatch();
   }
 

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -165,7 +165,6 @@ void FileOutputProcessor::initializeFileExport(FileExport& config) {
   config.setSampleTally(sampleTally_);
   // Every export begins from a clean slate.
   config.setExportError(kNoError);
-  config.setVideoLongerThanAudio(false);
   fileExportRepository_.update(config);
   // Reset the playback processor to stop any ongoing playback
   FilePlayback fpb = fpbr_.get();
@@ -264,12 +263,15 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
       }
     }
 
-    // Warn (independently of mux success/failure) when the supplied video
-    // outlasts the exported audio. Measured from the per-audio-element WAV
-    // writer's own frame count rather than re-reading any file, since that
-    // count already reflects exactly how many audio frames were written
-    // (accounting for start/end trim) and is still valid here -- the
-    // writers aren't cleared until after this block.
+    // Warn when the supplied video outlasts the exported audio, unless a more
+    // critical failure (a failed write or a failed mux, just above) is
+    // already on record -- only one of these can be shown to the user, and
+    // the failure to produce a correct file is the more important thing to
+    // surface. Measured from the per-audio-element WAV writer's own frame
+    // count rather than re-reading any file, since that count already
+    // reflects exactly how many audio frames were written (accounting for
+    // start/end trim) and is still valid here -- the writers aren't cleared
+    // until after this block.
     if (!iamfWavFileWriters_.empty() && sampleRate_ > 0) {
       constexpr double kDurationMismatchToleranceSec = 0.05;
       const double kAudioDurationSec =
@@ -281,8 +283,10 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
           kVideoDurationSec >
               kAudioDurationSec + kDurationMismatchToleranceSec) {
         FileExport freshConfig = fileExportRepository_.get();
-        freshConfig.setVideoLongerThanAudio(true);
-        fileExportRepository_.update(freshConfig);
+        if (freshConfig.getExportError() == kNoError) {
+          freshConfig.setExportError(kVideoLongerThanAudio);
+          fileExportRepository_.update(freshConfig);
+        }
       }
     }
   }

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -70,6 +70,7 @@ void FileOutputProcessor::prepareToPlay(const double sampleRate,
   }
   numSamples_ = samplesPerBlock;
   sampleTally_ = 0;
+  framesWritten_ = 0;
   sampleRate_ = sampleRate;
 }
 
@@ -104,6 +105,7 @@ void FileOutputProcessor::processBlock(juce::AudioBuffer<float>& buffer,
     // If we are not performing a render or the buffer is empty, do not write
     return;
   }
+  framesWritten_ += buffer.getNumSamples();
 
   // Process audio elements individually as Wav files
   for (int i = 0; i < iamfWavFileWriters_.size(); ++i) {
@@ -160,6 +162,7 @@ void FileOutputProcessor::initializeFileExport(FileExport& config) {
         config.getAudioCodec(), *audioElements[i]));
   }
   sampleTally_ = 0;
+  framesWritten_ = 0;
 
   // Set the sample tally in the configuration for FLAC encoding
   config.setSampleTally(sampleTally_);
@@ -263,29 +266,33 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
       }
     }
 
-    // Warn when the supplied video outlasts the exported audio, unless a more
-    // critical failure (a failed write or a failed mux, just above) is
-    // already on record -- only one of these can be shown to the user, and
-    // the failure to produce a correct file is the more important thing to
-    // surface. Measured from the per-audio-element WAV writer's own frame
-    // count rather than re-reading any file, since that count already
-    // reflects exactly how many audio frames were written (accounting for
-    // start/end trim) and is still valid here -- the writers aren't cleared
-    // until after this block.
-    if (!iamfWavFileWriters_.empty() && sampleRate_ > 0) {
+    // Warn when the supplied video and the exported audio don't run the same
+    // length, in either direction, unless a more critical failure (a failed
+    // write or a failed mux, just above) is already on record -- only one of
+    // these can be shown to the user, and the failure to produce a correct
+    // file is the more important thing to surface. Audio duration comes from
+    // framesWritten_ (tracked in processBlock) rather than any writer's own
+    // tally, so this doesn't depend on the per-audio-element WAV writers
+    // existing.
+    if (framesWritten_ > 0 && sampleRate_ > 0) {
       constexpr double kDurationMismatchToleranceSec = 0.05;
       const double kAudioDurationSec =
-          iamfWavFileWriters_[0]->getFramesWritten() / sampleRate_;
+          static_cast<double>(framesWritten_) / sampleRate_;
       const double kVideoDurationSec =
           IAMFExportHelper::getMediaDurationSeconds(
               fileExportRepository_.get().getVideoSource());
-      if (kVideoDurationSec > 0.0 &&
-          kVideoDurationSec >
-              kAudioDurationSec + kDurationMismatchToleranceSec) {
+      if (kVideoDurationSec > 0.0) {
         FileExport freshConfig = fileExportRepository_.get();
         if (freshConfig.getExportError() == kNoError) {
-          freshConfig.setExportError(kVideoLongerThanAudio);
-          fileExportRepository_.update(freshConfig);
+          if (kVideoDurationSec >
+              kAudioDurationSec + kDurationMismatchToleranceSec) {
+            freshConfig.setExportError(kVideoLongerThanAudio);
+            fileExportRepository_.update(freshConfig);
+          } else if (kAudioDurationSec >
+                     kVideoDurationSec + kDurationMismatchToleranceSec) {
+            freshConfig.setExportError(kAudioLongerThanVideo);
+            fileExportRepository_.update(freshConfig);
+          }
         }
       }
     }

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -322,7 +322,7 @@ bool FileOutputProcessor::shouldBufferBeWritten(
     return false;
   }
 
-  const long currentSample = sampleTally_;
+  const juce::int64 currentSample = sampleTally_;
   sampleTally_ += buffer.getNumSamples();
 
   // No range specified — write everything

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -165,6 +165,7 @@ void FileOutputProcessor::initializeFileExport(FileExport& config) {
   config.setSampleTally(sampleTally_);
   // Every export begins from a clean slate.
   config.setExportError(kNoError);
+  config.setVideoLongerThanAudio(false);
   fileExportRepository_.update(config);
   // Reset the playback processor to stop any ongoing playback
   FilePlayback fpb = fpbr_.get();
@@ -259,6 +260,28 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
       FileExport freshConfig = fileExportRepository_.get();
       if (freshConfig.getExportError() == kNoError) {
         freshConfig.setExportError(kMuxFailed);
+        fileExportRepository_.update(freshConfig);
+      }
+    }
+
+    // Warn (independently of mux success/failure) when the supplied video
+    // outlasts the exported audio. Measured from the per-audio-element WAV
+    // writer's own frame count rather than re-reading any file, since that
+    // count already reflects exactly how many audio frames were written
+    // (accounting for start/end trim) and is still valid here -- the
+    // writers aren't cleared until after this block.
+    if (!iamfWavFileWriters_.empty() && sampleRate_ > 0) {
+      constexpr double kDurationMismatchToleranceSec = 0.05;
+      const double kAudioDurationSec =
+          iamfWavFileWriters_[0]->getFramesWritten() / sampleRate_;
+      const double kVideoDurationSec =
+          IAMFExportHelper::getMediaDurationSeconds(
+              fileExportRepository_.get().getVideoSource());
+      if (kVideoDurationSec > 0.0 &&
+          kVideoDurationSec >
+              kAudioDurationSec + kDurationMismatchToleranceSec) {
+        FileExport freshConfig = fileExportRepository_.get();
+        freshConfig.setVideoLongerThanAudio(true);
         fileExportRepository_.update(freshConfig);
       }
     }

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -295,10 +295,14 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
 
 void FileOutputProcessor::checkAudioVideoDurationMismatch(
     double videoDurationSec) {
-  // Note: framesWritten_ == 0 is intentionally allowed through here (rather
-  // than gated out) so a zero-frame export against a video with a real
-  // duration still flags kVideoLongerThanAudio -- the most extreme case of
-  // exactly the mismatch this feature exists to catch.
+  // Note: framesWritten_ == 0 is intentionally NOT gated out here -- only
+  // sampleRate_ > 0 is required. This is defense-in-depth for a
+  // hypothetical future codec path that completes a zero-frame mux; today, a
+  // zero-frame export always fails the mux outright (kMuxFailed) before this
+  // function is ever reached (see
+  // FileOutputTests.mux_zero_frame_export_fails_mux_not_silently_skips), so
+  // the framesWritten_ == 0 case is not actually exercised via this branch in
+  // practice.
   if (!(sampleRate_ > 0)) {
     return;
   }
@@ -318,6 +322,15 @@ void FileOutputProcessor::checkAudioVideoDurationMismatch(
   }
   if (mismatchError != kNoError &&
       freshConfig.recordExportErrorIfUnset(mismatchError)) {
+    LOG_WARNING(0,
+                "FileOutputProcessor: Audio/video duration mismatch -- "
+                "audio: " +
+                    std::to_string(kAudioDurationSec) +
+                    "s, video: " + std::to_string(videoDurationSec) + "s (" +
+                    std::string(mismatchError == kVideoLongerThanAudio
+                                    ? "video longer than audio"
+                                    : "audio longer than video") +
+                    ").");
     fileExportRepository_.update(freshConfig);
   }
 }

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -114,8 +114,7 @@ void FileOutputProcessor::processBlock(juce::AudioBuffer<float>& buffer,
       // WAV size limit exceeded). Record it unless a more specific error is
       // already on record, mirroring the guard used for the IAMF path below.
       FileExport config = fileExportRepository_.get();
-      if (config.getExportError() == kNoError) {
-        config.setExportError(kFileWriteFailed);
+      if (config.recordExportErrorIfUnset(kFileWriteFailed)) {
         fileExportRepository_.update(config);
       }
     }
@@ -127,8 +126,7 @@ void FileOutputProcessor::processBlock(juce::AudioBuffer<float>& buffer,
     // more specific error is already on record, mirroring the guard used at
     // close-time and mux-time in closeFileExport.
     FileExport config = fileExportRepository_.get();
-    if (config.getExportError() == kNoError) {
-      config.setExportError(kFileWriteFailed);
+    if (config.recordExportErrorIfUnset(kFileWriteFailed)) {
       fileExportRepository_.update(config);
     }
   }
@@ -212,9 +210,8 @@ void FileOutputProcessor::initializeFileExport(FileExport& config) {
                 "file for writing: " +
                     writer->getFilePath());
       FileExport freshConfig = fileExportRepository_.get();
-      if (freshConfig.getExportError() == kNoError) {
-        freshConfig.setExportError(
-            classifyWriteFailure(juce::String(writer->getFilePath())));
+      if (freshConfig.recordExportErrorIfUnset(
+              classifyWriteFailure(juce::String(writer->getFilePath())))) {
         fileExportRepository_.update(freshConfig);
       }
     }
@@ -231,8 +228,7 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
       // already been recorded earlier in this export (mirrors the IAMF close
       // guard just below).
       FileExport freshConfig = fileExportRepository_.get();
-      if (freshConfig.getExportError() == kNoError) {
-        freshConfig.setExportError(kFileWriteFailed);
+      if (freshConfig.recordExportErrorIfUnset(kFileWriteFailed)) {
         fileExportRepository_.update(freshConfig);
       }
     }
@@ -247,8 +243,7 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
     // an unreported write failure. Only escalate if nothing more specific
     // has already been recorded earlier in this export.
     FileExport freshConfig = fileExportRepository_.get();
-    if (freshConfig.getExportError() == kNoError) {
-      freshConfig.setExportError(kFileWriteFailed);
+    if (freshConfig.recordExportErrorIfUnset(kFileWriteFailed)) {
       fileExportRepository_.update(freshConfig);
     }
   }
@@ -260,8 +255,7 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
       LOG_WARNING(0,
                   "IAMF Muxing: Failed to mux IAMF file with provided video.");
       FileExport freshConfig = fileExportRepository_.get();
-      if (freshConfig.getExportError() == kNoError) {
-        freshConfig.setExportError(kMuxFailed);
+      if (freshConfig.recordExportErrorIfUnset(kMuxFailed)) {
         fileExportRepository_.update(freshConfig);
       }
     }
@@ -280,16 +274,17 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
               fileExportRepository_.get().getVideoSource());
       if (kVideoDurationSec > 0.0) {
         FileExport freshConfig = fileExportRepository_.get();
-        if (freshConfig.getExportError() == kNoError) {
-          if (kVideoDurationSec >
-              kAudioDurationSec + kDurationMismatchToleranceSec) {
-            freshConfig.setExportError(kVideoLongerThanAudio);
-            fileExportRepository_.update(freshConfig);
-          } else if (kAudioDurationSec >
-                     kVideoDurationSec + kDurationMismatchToleranceSec) {
-            freshConfig.setExportError(kAudioLongerThanVideo);
-            fileExportRepository_.update(freshConfig);
-          }
+        ExportError mismatchError = kNoError;
+        if (kVideoDurationSec >
+            kAudioDurationSec + kDurationMismatchToleranceSec) {
+          mismatchError = kVideoLongerThanAudio;
+        } else if (kAudioDurationSec >
+                   kVideoDurationSec + kDurationMismatchToleranceSec) {
+          mismatchError = kAudioLongerThanVideo;
+        }
+        if (mismatchError != kNoError &&
+            freshConfig.recordExportErrorIfUnset(mismatchError)) {
+          fileExportRepository_.update(freshConfig);
         }
       }
     }

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -260,34 +260,11 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
       }
     }
 
-    // Warn when the supplied video and the exported audio don't run the same
-    // length, in either direction, unless a more critical failure (a failed
-    // write or a failed mux, just above) is already on record -- only one of
-    // these can be shown to the user, and the failure to produce a correct
-    // file is the more important thing to surface.
-    if (framesWritten_ > 0 && sampleRate_ > 0) {
-      constexpr double kDurationMismatchToleranceSec = 0.05;
-      const double kAudioDurationSec =
-          static_cast<double>(framesWritten_) / sampleRate_;
-      const double kVideoDurationSec =
-          IAMFExportHelper::getMediaDurationSeconds(
-              fileExportRepository_.get().getVideoSource());
-      if (kVideoDurationSec > 0.0) {
-        FileExport freshConfig = fileExportRepository_.get();
-        ExportError mismatchError = kNoError;
-        if (kVideoDurationSec >
-            kAudioDurationSec + kDurationMismatchToleranceSec) {
-          mismatchError = kVideoLongerThanAudio;
-        } else if (kAudioDurationSec >
-                   kVideoDurationSec + kDurationMismatchToleranceSec) {
-          mismatchError = kAudioLongerThanVideo;
-        }
-        if (mismatchError != kNoError &&
-            freshConfig.recordExportErrorIfUnset(mismatchError)) {
-          fileExportRepository_.update(freshConfig);
-        }
-      }
-    }
+    // Only escalate to the mismatch check if a more critical failure (a
+    // failed write or a failed mux, just above) is not already on record --
+    // only one of these can be shown to the user, and the failure to produce
+    // a correct file is the more important thing to surface.
+    checkAudioVideoDurationMismatch();
   }
 
   if (!config.getExportAudioElements()) {
@@ -309,6 +286,32 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
   LOG_DEBUG(0, "FileOutputProcessor: Stopping security scoped access");
   stopSecurityScopedAccess(securityScopedHandle_);
   securityScopedHandle_ = nullptr;
+}
+
+void FileOutputProcessor::checkAudioVideoDurationMismatch() {
+  if (!(framesWritten_ > 0 && sampleRate_ > 0)) {
+    return;
+  }
+  constexpr double kDurationMismatchToleranceSec = 0.05;
+  const double kAudioDurationSec =
+      static_cast<double>(framesWritten_) / sampleRate_;
+  const double kVideoDurationSec = IAMFExportHelper::getMediaDurationSeconds(
+      fileExportRepository_.get().getVideoSource());
+  if (kVideoDurationSec <= 0.0) {
+    return;
+  }
+  FileExport freshConfig = fileExportRepository_.get();
+  ExportError mismatchError = kNoError;
+  if (kVideoDurationSec > kAudioDurationSec + kDurationMismatchToleranceSec) {
+    mismatchError = kVideoLongerThanAudio;
+  } else if (kAudioDurationSec >
+             kVideoDurationSec + kDurationMismatchToleranceSec) {
+    mismatchError = kAudioLongerThanVideo;
+  }
+  if (mismatchError != kNoError &&
+      freshConfig.recordExportErrorIfUnset(mismatchError)) {
+    fileExportRepository_.update(freshConfig);
+  }
 }
 
 bool FileOutputProcessor::shouldBufferBeWritten(

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -248,8 +248,9 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
     }
   }
   if (kIamfExported && fileExportRepository_.get().getExportVideo()) {
-    const bool kMuxIamfSuccess =
-        IAMFExportHelper::muxIAMF(fileExportRepository_.get());
+    double videoDurationSec = -1.0;
+    const bool kMuxIamfSuccess = IAMFExportHelper::muxIAMF(
+        fileExportRepository_.get(), &videoDurationSec);
 
     if (!kMuxIamfSuccess) {
       LOG_WARNING(0,
@@ -267,7 +268,7 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
     // checkAudioVideoDurationMismatch() open the untrusted user-supplied
     // video file on a path that previously never touched it.
     if (kMuxIamfSuccess) {
-      checkAudioVideoDurationMismatch();
+      checkAudioVideoDurationMismatch(videoDurationSec);
     }
   }
 
@@ -292,24 +293,27 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
   securityScopedHandle_ = nullptr;
 }
 
-void FileOutputProcessor::checkAudioVideoDurationMismatch() {
-  if (!(framesWritten_ > 0 && sampleRate_ > 0)) {
+void FileOutputProcessor::checkAudioVideoDurationMismatch(
+    double videoDurationSec) {
+  // Note: framesWritten_ == 0 is intentionally allowed through here (rather
+  // than gated out) so a zero-frame export against a video with a real
+  // duration still flags kVideoLongerThanAudio -- the most extreme case of
+  // exactly the mismatch this feature exists to catch.
+  if (!(sampleRate_ > 0)) {
     return;
   }
   constexpr double kDurationMismatchToleranceSec = 0.05;
   const double kAudioDurationSec =
       static_cast<double>(framesWritten_) / sampleRate_;
-  const double kVideoDurationSec = IAMFExportHelper::getMediaDurationSeconds(
-      fileExportRepository_.get().getVideoSource());
-  if (kVideoDurationSec <= 0.0) {
+  if (videoDurationSec <= 0.0) {
     return;
   }
   FileExport freshConfig = fileExportRepository_.get();
   ExportError mismatchError = kNoError;
-  if (kVideoDurationSec > kAudioDurationSec + kDurationMismatchToleranceSec) {
+  if (videoDurationSec > kAudioDurationSec + kDurationMismatchToleranceSec) {
     mismatchError = kVideoLongerThanAudio;
   } else if (kAudioDurationSec >
-             kVideoDurationSec + kDurationMismatchToleranceSec) {
+             videoDurationSec + kDurationMismatchToleranceSec) {
     mismatchError = kAudioLongerThanVideo;
   }
   if (mismatchError != kNoError &&

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -262,11 +262,11 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
     }
 
     // Only run the mismatch check when the mux above succeeded. If it
-    // failed, kMuxFailed is already on record and the video file was never
-    // opened by muxIAMF() (muxVideo() short-circuits after a failed audio
-    // mux) -- gating here keeps that same invariant instead of having
-    // checkAudioVideoDurationMismatch() open the untrusted user-supplied
-    // video file on a path that previously never touched it.
+    // failed, kMuxFailed is already on record, and videoDurationSec may
+    // hold a duration muxVideo() read from the destination file before one
+    // of its own later failure points (final rename, track-count
+    // verification, etc.) -- gating here avoids acting on a duration read
+    // from a mux that did not actually complete.
     if (kMuxIamfSuccess) {
       checkAudioVideoDurationMismatch(videoDurationSec);
     }

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -270,10 +270,7 @@ void FileOutputProcessor::closeFileExport(const FileExport& config) {
     // length, in either direction, unless a more critical failure (a failed
     // write or a failed mux, just above) is already on record -- only one of
     // these can be shown to the user, and the failure to produce a correct
-    // file is the more important thing to surface. Audio duration comes from
-    // framesWritten_ (tracked in processBlock) rather than any writer's own
-    // tally, so this doesn't depend on the per-audio-element WAV writers
-    // existing.
+    // file is the more important thing to surface.
     if (framesWritten_ > 0 && sampleRate_ > 0) {
       constexpr double kDurationMismatchToleranceSec = 0.05;
       const double kAudioDurationSec =

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -84,14 +84,16 @@ class FileOutputProcessor : public ProcessorBase {
   void closeFileExport(const FileExport& config);
 
   // Warns when the supplied video and the exported audio don't run the same
-  // length, in either direction. Called from closeFileExport only after a
-  // successful mux -- a failed mux already means kMuxFailed is on record,
-  // and skipping the check keeps this from opening the video file on a path
-  // that previously never touched it. Also relies on
-  // FileExport::recordExportErrorIfUnset's first-recorded-error-wins
+  // length, in either direction. `videoDurationSec` is the video's duration
+  // as already computed by muxIAMF()/muxVideo() during muxing -- this avoids
+  // a second, independent parse of the untrusted video file. Called from
+  // closeFileExport only after a successful mux -- a failed mux already
+  // means kMuxFailed is on record, and skipping the check keeps this from
+  // opening the video file on a path that previously never touched it. Also
+  // relies on FileExport::recordExportErrorIfUnset's first-recorded-error-wins
   // semantics to stay silent if a more critical failure (a failed write) is
   // already on record.
-  void checkAudioVideoDurationMismatch();
+  void checkAudioVideoDurationMismatch(double videoDurationSec);
 
   bool shouldBufferBeWritten(const juce::AudioBuffer<float>& buffer);
 
@@ -114,8 +116,7 @@ class FileOutputProcessor : public ProcessorBase {
   juce::int64 startSampleIdx_;
   juce::int64 endSampleIdx_;
   juce::int64 sampleTally_;
-  juce::int64 framesWritten_ = 0;  // Count of samples actually handed to the
-                                   // writers this export
+  juce::int64 framesWritten_ = 0;  // samples handed to the writers this export
   std::unique_ptr<IAMFFileWriter> iamfFileWriter_;
   void* securityScopedHandle_ = nullptr;
   //==============================================================================

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -104,7 +104,8 @@ class FileOutputProcessor : public ProcessorBase {
   long startSampleIdx_;
   long endSampleIdx_;
   long sampleTally_;
-  long framesWritten_; // Count of samples actually handed to the writers this export
+  long framesWritten_;  // Count of samples actually handed to the writers
+                        // this export
   std::unique_ptr<IAMFFileWriter> iamfFileWriter_;
   void* securityScopedHandle_ = nullptr;
   //==============================================================================

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -84,8 +84,11 @@ class FileOutputProcessor : public ProcessorBase {
   void closeFileExport(const FileExport& config);
 
   // Warns when the supplied video and the exported audio don't run the same
-  // length, in either direction, unless a more critical failure is already
-  // on record. Called from closeFileExport after a successful mux.
+  // length, in either direction. Called from closeFileExport whenever a mux
+  // was attempted, whether or not it succeeded; relies on
+  // FileExport::recordExportErrorIfUnset's first-recorded-error-wins
+  // semantics to stay silent if a more critical failure (a failed write or a
+  // failed mux) is already on record.
   void checkAudioVideoDurationMismatch();
 
   bool shouldBufferBeWritten(const juce::AudioBuffer<float>& buffer);

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -104,11 +104,7 @@ class FileOutputProcessor : public ProcessorBase {
   long startSampleIdx_;
   long endSampleIdx_;
   long sampleTally_;
-  // Count of samples actually handed to the writers this export (respecting
-  // start/end trim), tracked here rather than read back from any individual
-  // writer so the duration-mismatch check in closeFileExport doesn't depend
-  // on the per-audio-element WAV writers existing.
-  long framesWritten_;
+  long framesWritten_; // Count of samples actually handed to the writers this export
   std::unique_ptr<IAMFFileWriter> iamfFileWriter_;
   void* securityScopedHandle_ = nullptr;
   //==============================================================================

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -83,6 +83,11 @@ class FileOutputProcessor : public ProcessorBase {
 
   void closeFileExport(const FileExport& config);
 
+  // Warns when the supplied video and the exported audio don't run the same
+  // length, in either direction, unless a more critical failure is already
+  // on record. Called from closeFileExport after a successful mux.
+  void checkAudioVideoDurationMismatch();
+
   bool shouldBufferBeWritten(const juce::AudioBuffer<float>& buffer);
 
   // Classifies a file write failure by probing whether the parent directory

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -84,11 +84,13 @@ class FileOutputProcessor : public ProcessorBase {
   void closeFileExport(const FileExport& config);
 
   // Warns when the supplied video and the exported audio don't run the same
-  // length, in either direction. Called from closeFileExport whenever a mux
-  // was attempted, whether or not it succeeded; relies on
+  // length, in either direction. Called from closeFileExport only after a
+  // successful mux -- a failed mux already means kMuxFailed is on record,
+  // and skipping the check keeps this from opening the video file on a path
+  // that previously never touched it. Also relies on
   // FileExport::recordExportErrorIfUnset's first-recorded-error-wins
-  // semantics to stay silent if a more critical failure (a failed write or a
-  // failed mux) is already on record.
+  // semantics to stay silent if a more critical failure (a failed write) is
+  // already on record.
   void checkAudioVideoDurationMismatch();
 
   bool shouldBufferBeWritten(const juce::AudioBuffer<float>& buffer);

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -104,6 +104,11 @@ class FileOutputProcessor : public ProcessorBase {
   long startSampleIdx_;
   long endSampleIdx_;
   long sampleTally_;
+  // Count of samples actually handed to the writers this export (respecting
+  // start/end trim), tracked here rather than read back from any individual
+  // writer so the duration-mismatch check in closeFileExport doesn't depend
+  // on the per-audio-element WAV writers existing.
+  long framesWritten_;
   std::unique_ptr<IAMFFileWriter> iamfFileWriter_;
   void* securityScopedHandle_ = nullptr;
   //==============================================================================

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -86,13 +86,16 @@ class FileOutputProcessor : public ProcessorBase {
   // Warns when the supplied video and the exported audio don't run the same
   // length, in either direction. `videoDurationSec` is the video's duration
   // as already computed by muxIAMF()/muxVideo() during muxing -- this avoids
-  // a second, independent parse of the untrusted video file. Called from
+  // a second, independent parse of the video file. Called from
   // closeFileExport only after a successful mux -- a failed mux already
-  // means kMuxFailed is on record, and skipping the check keeps this from
-  // opening the video file on a path that previously never touched it. Also
-  // relies on FileExport::recordExportErrorIfUnset's first-recorded-error-wins
-  // semantics to stay silent if a more critical failure (a failed write) is
-  // already on record.
+  // means kMuxFailed is on record, and skipping the check avoids acting on
+  // videoDurationSec, which muxVideo() sets from the destination file's
+  // in-progress track duration before some of its own later failure points
+  // (final rename, track-count verification, etc.); on those failure paths
+  // the value can look valid even though the mux as a whole did not
+  // complete. Also relies on FileExport::recordExportErrorIfUnset's
+  // first-recorded-error-wins semantics to stay silent if a more critical
+  // failure (a failed write) is already on record.
   void checkAudioVideoDurationMismatch(double videoDurationSec);
 
   bool shouldBufferBeWritten(const juce::AudioBuffer<float>& buffer);

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -112,8 +112,8 @@ class FileOutputProcessor : public ProcessorBase {
   long startSampleIdx_;
   long endSampleIdx_;
   long sampleTally_;
-  long framesWritten_;  // Count of samples actually handed to the writers
-                        // this export
+  juce::int64 framesWritten_ = 0;  // Count of samples actually handed to the
+                                   // writers this export
   std::unique_ptr<IAMFFileWriter> iamfFileWriter_;
   void* securityScopedHandle_ = nullptr;
   //==============================================================================

--- a/common/processors/file_output/FileOutputProcessor.h
+++ b/common/processors/file_output/FileOutputProcessor.h
@@ -109,9 +109,9 @@ class FileOutputProcessor : public ProcessorBase {
   std::vector<std::unique_ptr<AudioElementFileWriter>> iamfWavFileWriters_;
   int numSamples_;
   double sampleRate_;
-  long startSampleIdx_;
-  long endSampleIdx_;
-  long sampleTally_;
+  juce::int64 startSampleIdx_;
+  juce::int64 endSampleIdx_;
+  juce::int64 sampleTally_;
   juce::int64 framesWritten_ = 0;  // Count of samples actually handed to the
                                    // writers this export
   std::unique_ptr<IAMFFileWriter> iamfFileWriter_;

--- a/common/processors/file_output/FileOutputProcessor_PremierePro.cpp
+++ b/common/processors/file_output/FileOutputProcessor_PremierePro.cpp
@@ -85,6 +85,7 @@ void PremiereProFileOutputProcessor::processBlock(
   if (!shouldBufferBeWritten(buffer)) {
     return;
   }
+  framesWritten_ += buffer.getNumSamples();
 
   //  Write the audio data to the wav file writers
   for (auto& writer : iamfWavFileWriters_) {

--- a/common/processors/file_output/FileOutputProcessor_PremierePro.cpp
+++ b/common/processors/file_output/FileOutputProcessor_PremierePro.cpp
@@ -56,6 +56,7 @@ void PremiereProFileOutputProcessor::prepareToPlay(double sampleRate,
 
   numSamples_ = samplesPerBlock;
   sampleTally_ = 0;
+  framesWritten_ = 0;
   sampleRate_ = sampleRate;
 }
 

--- a/common/processors/file_output/FileOutputProcessor_PremierePro.cpp
+++ b/common/processors/file_output/FileOutputProcessor_PremierePro.cpp
@@ -96,8 +96,7 @@ void PremiereProFileOutputProcessor::processBlock(
       // mirroring the guard used for the IAMF path below and in the base
       // FileOutputProcessor::processBlock.
       FileExport config = fileExportRepository_.get();
-      if (config.getExportError() == kNoError) {
-        config.setExportError(kFileWriteFailed);
+      if (config.recordExportErrorIfUnset(kFileWriteFailed)) {
         fileExportRepository_.update(config);
       }
     }
@@ -111,8 +110,7 @@ void PremiereProFileOutputProcessor::processBlock(
     // export path leaves performingRender_ true but iamfFileWriter_ unset),
     // which this override previously dereferenced unconditionally.
     FileExport config = fileExportRepository_.get();
-    if (config.getExportError() == kNoError) {
-      config.setExportError(kFileWriteFailed);
+    if (config.recordExportErrorIfUnset(kFileWriteFailed)) {
       fileExportRepository_.update(config);
     }
   }

--- a/common/processors/file_output/WavFileOutputProcessor.cpp
+++ b/common/processors/file_output/WavFileOutputProcessor.cpp
@@ -116,9 +116,7 @@ void WavFileOutputProcessor::recordWriteFailureIfAny(bool writeSucceeded) {
   // Deferred via deferRepositoryUpdate() -- see its declaration for why this
   // can't call fileExportRepository_.update() synchronously.
   deferRepositoryUpdate([](FileExport& config) {
-    if (config.getExportError() == kNoError) {
-      config.setExportError(kFileWriteFailed);
-    }
+    config.recordExportErrorIfUnset(kFileWriteFailed);
   });
 }
 
@@ -150,10 +148,8 @@ void WavFileOutputProcessor::setNonRealtime(bool isNonRealtime) noexcept {
                   "WavFileOutputProcessor: Failed to open file for writing: " +
                       kFailedFilePath);
         deferRepositoryUpdate([kFailedFilePath](FileExport& config) {
-          if (config.getExportError() == kNoError) {
-            config.setExportError(
-                classifyWriteFailure(juce::String(kFailedFilePath)));
-          }
+          config.recordExportErrorIfUnset(
+              classifyWriteFailure(juce::String(kFailedFilePath)));
         });
       }
       performingRender_ = true;
@@ -166,9 +162,7 @@ void WavFileOutputProcessor::setNonRealtime(bool isNonRealtime) noexcept {
         // an unreported write failure. Only escalate if nothing more
         // specific has already been recorded earlier in this export.
         deferRepositoryUpdate([](FileExport& config) {
-          if (config.getExportError() == kNoError) {
-            config.setExportError(kFileWriteFailed);
-          }
+          config.recordExportErrorIfUnset(kFileWriteFailed);
         });
       }
       delete fileWriter_;

--- a/common/processors/file_output/WavFileOutputProcessor.cpp
+++ b/common/processors/file_output/WavFileOutputProcessor.cpp
@@ -84,8 +84,8 @@ void WavFileOutputProcessor::processBlock(juce::AudioBuffer<float>& buffer,
     auto playHead = getPlayHead();
     if (playHead != NULL) {  // Happens in debug
       auto position = getPlayHead()->getPosition();
-      const long currentSample =
-          static_cast<long>(*position->getTimeInSeconds() * sampleRate_);
+      const juce::int64 currentSample =
+          static_cast<juce::int64>(*position->getTimeInSeconds() * sampleRate_);
       if ((endSampleIdx_ == 0) || (currentSample >= startSampleIdx_ &&
                                    currentSample <= endSampleIdx_)) {
         writeFailed = !fileWriter_->write(buffer);

--- a/common/processors/file_output/WavFileOutputProcessor.h
+++ b/common/processors/file_output/WavFileOutputProcessor.h
@@ -121,8 +121,8 @@ class WavFileOutputProcessor : public ProcessorBase,
   FileWriter* fileWriter_;
   int numSamples_;
   double sampleRate_;
-  long startSampleIdx_;
-  long endSampleIdx_;
+  juce::int64 startSampleIdx_;
+  juce::int64 endSampleIdx_;
   juce::SpinLock lock_;
   std::atomic<bool> hasRecordedWriteFailure_ = false;
   std::shared_ptr<std::atomic<bool>> isAlive_ =

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -231,9 +231,13 @@ static bool muxIAMFAudio(const juce::String& inputAudioFile,
   return true;
 }
 
-// Writes video to an existing MP4 file using GPAC ISO media APIs
+// Writes video to an existing MP4 file using GPAC ISO media APIs. When
+// non-null, `outVideoDurationSec` is set to the video track's own duration
+// (in seconds), read from the already-open destination file handle instead
+// of requiring a caller to reopen/reparse the file separately.
 static bool muxVideo(const juce::String& inputVideoFile,
-                     const juce::String& outputMuxedFile) {
+                     const juce::String& outputMuxedFile,
+                     double* outVideoDurationSec = nullptr) {
 #ifdef DEBUG
   gf_log_set_tool_level(GF_LOG_CORE, GF_LOG_INFO);
   gf_log_set_tool_level(GF_LOG_CONTAINER, GF_LOG_INFO);
@@ -328,6 +332,12 @@ static bool muxVideo(const juce::String& inputVideoFile,
   // Without this, if the IAMF audio is longer than the video, the container
   // reports the audio length as the movie duration.
   u64 video_track_duration = gf_isom_get_track_duration(dst_file, dst_track);
+  if (outVideoDurationSec) {
+    const u32 kTimescale = gf_isom_get_timescale(dst_file);
+    *outVideoDurationSec =
+        kTimescale > 0 ? static_cast<double>(video_track_duration) / kTimescale
+                       : -1.0;
+  }
   if (video_track_duration > 0) {
     u32 track_count = gf_isom_get_track_count(dst_file);
     for (u32 i = 1; i <= track_count; i++) {
@@ -403,7 +413,7 @@ static bool muxVideo(const juce::String& inputVideoFile,
   return true;
 }
 
-bool muxIAMF(const FileExport& exportData) {
+bool muxIAMF(const FileExport& exportData, double* outVideoDurationSec) {
   const juce::String inputAudioFile = exportData.getExportFile();
   const juce::String inputVideoFile = exportData.getVideoSource();
   const juce::String outputMuxdFile = exportData.getVideoExportFolder();
@@ -425,7 +435,7 @@ bool muxIAMF(const FileExport& exportData) {
     gf_sys_close();
     return false;
   }
-  if (!muxVideo(inputVideoFile, outputMuxdFile)) {
+  if (!muxVideo(inputVideoFile, outputMuxdFile, outVideoDurationSec)) {
     LOG_ERROR(0, "IAMF Muxing: Failed to mux video into MP4.");
     gf_sys_close();
     return false;

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -436,7 +436,7 @@ bool muxIAMF(const FileExport& exportData) {
 
 double getMediaDurationSeconds(const juce::String& mediaFilePath) {
   std::unique_ptr<GF_ISOFile, decltype(&gf_isom_close)> file(
-      gf_isom_open(mediaFilePath.toRawUTF8(), GF_ISOM_OPEN_READ, NULL),
+      gf_isom_open(mediaFilePath.toRawUTF8(), GF_ISOM_OPEN_READ, nullptr),
       &gf_isom_close);
   if (!file) return -1.0;
   const u32 timescale = gf_isom_get_timescale(file.get());

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -19,6 +19,8 @@
 #include <gpac/tools.h>
 #include <logger/logger.h>
 
+#include <memory>
+
 #include "gpac/tools.h"
 
 namespace IAMFExportHelper {
@@ -433,26 +435,26 @@ bool muxIAMF(const FileExport& exportData) {
 }
 
 double getMediaDurationSeconds(const juce::String& mediaFilePath) {
-  GF_ISOFile* file =
-      gf_isom_open(mediaFilePath.toRawUTF8(), GF_ISOM_OPEN_READ, NULL);
+  std::unique_ptr<GF_ISOFile, decltype(&gf_isom_close)> file(
+      gf_isom_open(mediaFilePath.toRawUTF8(), GF_ISOM_OPEN_READ, NULL),
+      &gf_isom_close);
   if (!file) return -1.0;
-  const u32 timescale = gf_isom_get_timescale(file);
+  const u32 timescale = gf_isom_get_timescale(file.get());
 
   // Prefer the video track's own duration (movie timescale, same as
   // gf_isom_get_duration below) over the container-level duration: a file
   // with a non-visual track (e.g. embedded audio) whose length differs from
   // the video would otherwise report the wrong duration here, the same
   // pitfall muxVideo() above already works around for the muxed output.
-  u64 duration = gf_isom_get_duration(file);
-  const u32 trackCount = gf_isom_get_track_count(file);
+  u64 duration = gf_isom_get_duration(file.get());
+  const u32 trackCount = gf_isom_get_track_count(file.get());
   for (u32 i = 1; i <= trackCount; i++) {
-    if (gf_isom_get_media_type(file, i) == GF_ISOM_MEDIA_VISUAL) {
-      duration = gf_isom_get_track_duration(file, i);
+    if (gf_isom_get_media_type(file.get(), i) == GF_ISOM_MEDIA_VISUAL) {
+      duration = gf_isom_get_track_duration(file.get(), i);
       break;
     }
   }
 
-  gf_isom_close(file);
   return timescale > 0 ? static_cast<double>(duration) / timescale : -1.0;
 }
 

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -70,7 +70,8 @@ void writeLPCMConfigMD(const int samplesPerBlock, const int sampleRate,
   lpcmConfigMD->set_sample_rate(sampleRate);
 }
 
-void writeFLACConfigMD(const int samplesPerBlock, const int samplesProcessed,
+void writeFLACConfigMD(const int samplesPerBlock,
+                       const juce::int64 samplesProcessed,
                        const int bitsPerSample, const int compressionLevel,
                        const int sampleRate,
                        iamf_tools_cli_proto::UserMetadata& user_metadata) {
@@ -435,27 +436,48 @@ bool muxIAMF(const FileExport& exportData) {
 }
 
 double getMediaDurationSeconds(const juce::String& mediaFilePath) {
-  std::unique_ptr<GF_ISOFile, decltype(&gf_isom_close)> file(
-      gf_isom_open(mediaFilePath.toRawUTF8(), GF_ISOM_OPEN_READ, nullptr),
-      &gf_isom_close);
-  if (!file) return -1.0;
-  const u32 timescale = gf_isom_get_timescale(file.get());
+  // GPAC requires gf_sys_init()/gf_sys_close() to bracket use of its APIs;
+  // this function can run independently of muxIAMF() (whose own
+  // init/close bracket does not cover this call), so it brackets its own
+  // GPAC calls here.
+  GF_Err init_err = gf_sys_init(GF_MemTrackerNone, NULL);
+  if (init_err != GF_OK) {
+    LOG_ERROR(0, "IAMF Muxing: Failed to initialize GPAC system.");
+    return -1.0;
+  }
 
-  // Prefer the video track's own duration (movie timescale, same as
-  // gf_isom_get_duration below) over the container-level duration: a file
-  // with a non-visual track (e.g. embedded audio) whose length differs from
-  // the video would otherwise report the wrong duration here, the same
-  // pitfall muxVideo() above already works around for the muxed output.
-  u64 duration = gf_isom_get_duration(file.get());
-  const u32 trackCount = gf_isom_get_track_count(file.get());
-  for (u32 i = 1; i <= trackCount; i++) {
-    if (gf_isom_get_media_type(file.get(), i) == GF_ISOM_MEDIA_VISUAL) {
-      duration = gf_isom_get_track_duration(file.get(), i);
-      break;
+  // Scoped so the isom file is closed (via the unique_ptr's deleter) before
+  // gf_sys_close() tears down GPAC's global state below -- gf_isom_close()
+  // must run while GPAC is still initialized.
+  double result = -1.0;
+  {
+    std::unique_ptr<GF_ISOFile, decltype(&gf_isom_close)> file(
+        gf_isom_open(mediaFilePath.toRawUTF8(), GF_ISOM_OPEN_READ, nullptr),
+        &gf_isom_close);
+    if (file) {
+      const u32 timescale = gf_isom_get_timescale(file.get());
+
+      // Prefer the video track's own duration (movie timescale, same as
+      // gf_isom_get_duration below) over the container-level duration: a
+      // file with a non-visual track (e.g. embedded audio) whose length
+      // differs from the video would otherwise report the wrong duration
+      // here, the same pitfall muxVideo() above already works around for
+      // the muxed output.
+      u64 duration = gf_isom_get_duration(file.get());
+      const u32 trackCount = gf_isom_get_track_count(file.get());
+      for (u32 i = 1; i <= trackCount; i++) {
+        if (gf_isom_get_media_type(file.get(), i) == GF_ISOM_MEDIA_VISUAL) {
+          duration = gf_isom_get_track_duration(file.get(), i);
+          break;
+        }
+      }
+
+      result = timescale > 0 ? static_cast<double>(duration) / timescale : -1.0;
     }
   }
 
-  return timescale > 0 ? static_cast<double>(duration) / timescale : -1.0;
+  gf_sys_close();
+  return result;
 }
 
 std::vector<const AudioElement*> filterFreeAudioElements(

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -450,7 +450,7 @@ double getMediaDurationSeconds(const juce::String& mediaFilePath) {
   // this function can run independently of muxIAMF() (whose own
   // init/close bracket does not cover this call), so it brackets its own
   // GPAC calls here.
-  GF_Err init_err = gf_sys_init(GF_MemTrackerNone, NULL);
+  GF_Err init_err = gf_sys_init(GF_MemTrackerNone, nullptr);
   if (init_err != GF_OK) {
     LOG_ERROR(0, "IAMF Muxing: Failed to initialize GPAC system.");
     return -1.0;

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -437,7 +437,21 @@ double getMediaDurationSeconds(const juce::String& mediaFilePath) {
       gf_isom_open(mediaFilePath.toRawUTF8(), GF_ISOM_OPEN_READ, NULL);
   if (!file) return -1.0;
   const u32 timescale = gf_isom_get_timescale(file);
-  const u64 duration = gf_isom_get_duration(file);
+
+  // Prefer the video track's own duration (movie timescale, same as
+  // gf_isom_get_duration below) over the container-level duration: a file
+  // with a non-visual track (e.g. embedded audio) whose length differs from
+  // the video would otherwise report the wrong duration here, the same
+  // pitfall muxVideo() above already works around for the muxed output.
+  u64 duration = gf_isom_get_duration(file);
+  const u32 trackCount = gf_isom_get_track_count(file);
+  for (u32 i = 1; i <= trackCount; i++) {
+    if (gf_isom_get_media_type(file, i) == GF_ISOM_MEDIA_VISUAL) {
+      duration = gf_isom_get_track_duration(file, i);
+      break;
+    }
+  }
+
   gf_isom_close(file);
   return timescale > 0 ? static_cast<double>(duration) / timescale : -1.0;
 }

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.cpp
@@ -432,6 +432,16 @@ bool muxIAMF(const FileExport& exportData) {
   return true;
 }
 
+double getMediaDurationSeconds(const juce::String& mediaFilePath) {
+  GF_ISOFile* file =
+      gf_isom_open(mediaFilePath.toRawUTF8(), GF_ISOM_OPEN_READ, NULL);
+  if (!file) return -1.0;
+  const u32 timescale = gf_isom_get_timescale(file);
+  const u64 duration = gf_isom_get_duration(file);
+  gf_isom_close(file);
+  return timescale > 0 ? static_cast<double>(duration) / timescale : -1.0;
+}
+
 std::vector<const AudioElement*> filterFreeAudioElements(
     const juce::OwnedArray<AudioElement>& audioElements,
     const juce::OwnedArray<MixPresentation>& mixPresentations) {

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
@@ -27,7 +27,8 @@ void writeIASeqHdr(FileProfile profileVersion,
 void writeLPCMConfigMD(const int samplesPerBlock, const int sampleRate,
                        const int sampleSize,
                        iamf_tools_cli_proto::UserMetadata& user_metadata);
-void writeFLACConfigMD(const int samplesPerBlock, const int samplesProcessed,
+void writeFLACConfigMD(const int samplesPerBlock,
+                       const juce::int64 samplesProcessed,
                        const int bitsPerSample, const int compressionLevel,
                        const int sampleRate,
                        iamf_tools_cli_proto::UserMetadata& user_metadata);

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
@@ -38,4 +38,9 @@ std::vector<const AudioElement*> filterFreeAudioElements(
     const juce::OwnedArray<AudioElement>& audioElements,
     const juce::OwnedArray<MixPresentation>& mixPresentations);
 bool muxIAMF(const FileExport& exportData);
+
+// Returns the media file's duration in seconds (movie-level duration /
+// timescale), or -1.0 if the file cannot be opened or has no timescale.
+// Read-only container inspection -- does not mutate the file.
+double getMediaDurationSeconds(const juce::String& mediaFilePath);
 }  // namespace IAMFExportHelper

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
@@ -39,7 +39,9 @@ std::vector<const AudioElement*> filterFreeAudioElements(
     const juce::OwnedArray<MixPresentation>& mixPresentations);
 bool muxIAMF(const FileExport& exportData);
 
-// Returns the media file's duration in seconds (movie-level duration /
-// timescale), or -1.0 if the file cannot be opened or has no timescale.
+// Returns the media file's duration in seconds, or -1.0 if the file cannot
+// be opened or has no timescale. Prefers the first video track's own
+// duration over the movie/container-level duration, falling back to the
+// container duration if the file has no visual track.
 [[nodiscard]] double getMediaDurationSeconds(const juce::String& mediaFilePath);
 }  // namespace IAMFExportHelper

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
@@ -38,7 +38,14 @@ void writeOPUSConfigMD(const int samplesPerBlock, const int sampleRate,
 std::vector<const AudioElement*> filterFreeAudioElements(
     const juce::OwnedArray<AudioElement>& audioElements,
     const juce::OwnedArray<MixPresentation>& mixPresentations);
-bool muxIAMF(const FileExport& exportData);
+// Muxes the exported IAMF audio and configured video source together.
+// When non-null, `outVideoDurationSec` is set to the video track's own
+// duration (in seconds) as already computed during muxing -- callers that
+// need the video's duration should read it from here instead of a second,
+// independent parse of the video file (see getMediaDurationSeconds below).
+// Left untouched if muxing fails before the video file is opened.
+bool muxIAMF(const FileExport& exportData,
+             double* outVideoDurationSec = nullptr);
 
 // Returns the media file's duration in seconds, or -1.0 if the file cannot
 // be opened or has no timescale. Prefers the first video track's own

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
@@ -41,6 +41,5 @@ bool muxIAMF(const FileExport& exportData);
 
 // Returns the media file's duration in seconds (movie-level duration /
 // timescale), or -1.0 if the file cannot be opened or has no timescale.
-// Read-only container inspection -- does not mutate the file.
 double getMediaDurationSeconds(const juce::String& mediaFilePath);
 }  // namespace IAMFExportHelper

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
@@ -41,5 +41,5 @@ bool muxIAMF(const FileExport& exportData);
 
 // Returns the media file's duration in seconds (movie-level duration /
 // timescale), or -1.0 if the file cannot be opened or has no timescale.
-double getMediaDurationSeconds(const juce::String& mediaFilePath);
+[[nodiscard]] double getMediaDurationSeconds(const juce::String& mediaFilePath);
 }  // namespace IAMFExportHelper

--- a/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
+++ b/common/processors/file_output/iamf_export_utils/IAMFExportUtil.h
@@ -51,5 +51,16 @@ bool muxIAMF(const FileExport& exportData,
 // be opened or has no timescale. Prefers the first video track's own
 // duration over the movie/container-level duration, falling back to the
 // container duration if the file has no visual track.
+//
+// Deliberately NOT called from the mismatch-warning feature's own production
+// path: muxIAMF()'s outVideoDurationSec already returns the muxed output's
+// video-track duration from the destination file it has open during muxing,
+// so calling this too would just re-parse that same file a second,
+// independent time. This is a general-purpose utility -- usable against any
+// media file, not just a just-muxed one -- kept here (with its own
+// dedicated unit test, get_media_duration_uses_video_track_not_container)
+// for future callers that need a duration read outside the muxing path, e.g.
+// validating the source video before mux starts. It has no production
+// caller today; that is intentional, not an oversight.
 [[nodiscard]] double getMediaDurationSeconds(const juce::String& mediaFilePath);
 }  // namespace IAMFExportHelper

--- a/common/processors/loudness_export/LoudnessExportProcessor.cpp
+++ b/common/processors/loudness_export/LoudnessExportProcessor.cpp
@@ -265,9 +265,9 @@ bool LoudnessExportProcessor::areLoudnessCalcsRequired(
     return false;
   }
 
-  const long currentSample = sampleTally_;
+  const juce::int64 currentSample = sampleTally_;
   sampleTally_ += buffer.getNumSamples();
-  const long nextSample = sampleTally_;
+  const juce::int64 nextSample = sampleTally_;
 
   if (startSampleIdx_ != 0 || endSampleIdx_ != 0) {
     // Handle the case where startSampleIdx and endSampleIdx are set, implying

--- a/common/processors/loudness_export/LoudnessExportProcessor.h
+++ b/common/processors/loudness_export/LoudnessExportProcessor.h
@@ -78,9 +78,9 @@ class LoudnessExportProcessor : public ProcessorBase,
 
   long sampleRate_;
   int currentSamplesPerBlock_;
-  long sampleTally_;
-  long startSampleIdx_;
-  long endSampleIdx_;
+  juce::int64 sampleTally_;
+  juce::int64 startSampleIdx_;
+  juce::int64 endSampleIdx_;
 
   std::vector<MixPresentationLoudnessExportContainer> exportContainers_;
 };

--- a/common/processors/tests/FileOutputProcessor_PremierePro_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_PremierePro_test.cpp
@@ -118,6 +118,27 @@ TEST_F(FileOutputTests, pp_invalid_path_does_not_crash) {
             ExportError::kInvalidExportPath);
 }
 
+// Regression test: PremiereProFileOutputProcessor::processBlock previously
+// never incremented framesWritten_ (only the base FileOutputProcessor's
+// override did), so the audio/video duration-mismatch check in the shared,
+// inherited closeFileExport() was always guarded off (framesWritten_ stayed
+// 0) for every Premiere Pro export, silently defeating the warning for this
+// entire export path.
+TEST_F(FileOutputTests, pp_flags_mismatch_when_video_longer_than_audio) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+
+  bouncePremiereProAudio(fileExportRepository, fpbr, audioElementRepository,
+                         mixRepository, mixPresentationLoudnessRepository);
+
+  ASSERT_TRUE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kVideoLongerThanAudio);
+}
+
 TEST_F(FileOutputTests, pp_validate_file_checksum) {
   const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
   const juce::Uuid kMP = addMixPresentation();

--- a/common/processors/tests/FileOutputProcessor_PremierePro_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_PremierePro_test.cpp
@@ -139,6 +139,51 @@ TEST_F(FileOutputTests, pp_flags_mismatch_when_video_longer_than_audio) {
             ExportError::kVideoLongerThanAudio);
 }
 
+// Regression test: the base FileOutputProcessor test suite covers the
+// opposite direction (audio outlasting video) and the no-mismatch case, but
+// the Premiere Pro path -- whose framesWritten_ tracking this PR also fixes
+// -- previously only exercised the video-longer-than-audio direction above.
+// Rendering well past the ~3.77s test video's duration means the exported
+// audio now outlasts the video, so the export error should flip to the
+// opposite-direction warning instead of clearing.
+TEST_F(FileOutputTests, pp_flags_mismatch_when_audio_longer_than_video) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+
+  // ~5.3 seconds at 48kHz/128 frames per block -- longer than the ~3.77s
+  // default test video.
+  bouncePremiereProAudio(fileExportRepository, fpbr, audioElementRepository,
+                         mixRepository, mixPresentationLoudnessRepository,
+                         48000, 128, 2000);
+
+  ASSERT_TRUE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kAudioLongerThanVideo);
+}
+
+// Regression test: bouncing audio to closely match the test video's own
+// ~3.77s duration on the Premiere Pro path should leave the export error
+// clear in either direction, mirroring the base FileOutputProcessor coverage.
+TEST_F(FileOutputTests, pp_no_mismatch_when_durations_match) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+
+  // ~3.77 seconds at 48kHz/128 frames per block -- matches the default test
+  // video's own duration within the mismatch tolerance.
+  bouncePremiereProAudio(fileExportRepository, fpbr, audioElementRepository,
+                         mixRepository, mixPresentationLoudnessRepository,
+                         48000, 128, 1413);
+
+  ASSERT_TRUE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+}
+
 TEST_F(FileOutputTests, pp_validate_file_checksum) {
   const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
   const juce::Uuid kMP = addMixPresentation();

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -330,6 +330,41 @@ TEST_F(FileOutputTests, mux_iamf_container_duration_matches_video) {
   EXPECT_NEAR(outputDuration, videoDuration, 0.1);
 }
 
+// Issue #38: the default bounce (~21ms) is far shorter than the ~3.8s test
+// video, so the export must still succeed (no ExportError) but flag the
+// duration mismatch for the UI to warn on.
+TEST_F(FileOutputTests, mux_flags_mismatch_when_video_longer_than_audio) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+
+  bounceAudio(fio_proc, audioElementRepository);
+
+  ASSERT_TRUE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+  EXPECT_TRUE(fileExportRepository.get().getVideoLongerThanAudio());
+}
+
+// Issue #38: rendering well past the ~3.8s test video's duration means audio
+// is no longer shorter than video, so the mismatch flag must stay clear.
+TEST_F(FileOutputTests, mux_no_mismatch_when_audio_covers_video_duration) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+
+  // ~5.3 seconds at 48kHz/128 frames per block -- longer than the ~3.8s
+  // default test video.
+  bounceAudio(fio_proc, audioElementRepository, 48000, 128, 2000);
+
+  ASSERT_TRUE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+  EXPECT_FALSE(fileExportRepository.get().getVideoLongerThanAudio());
+}
+
 // Codec param tests. These tests focus on testing advanced codec specific file
 // export configurations. As such, the configuration is kept local to the tests
 // rather than being done through the generic `setTestExportOpts` function.

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -400,6 +400,35 @@ TEST_F(FileOutputTests, mux_no_mismatch_when_durations_match) {
   EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
 }
 
+// Regression test: closeFileExport documents that
+// checkAudioVideoDurationMismatch runs unconditionally after a mux attempt and
+// relies on FileExport::recordExportErrorIfUnset's first-recorded-error-wins
+// semantics to stay silent when a more critical failure is already on record --
+// but nothing previously exercised a case where a mux failure AND a genuine
+// duration mismatch would both fire, to confirm the mux failure wins. Point the
+// video export folder at an invalid path (forcing a mux failure) while keeping
+// the video source at the default ~3.77s test video and rendering only the
+// default short (~21ms) bounce, which alone would trip kVideoLongerThanAudio --
+// the export error must still surface as kMuxFailed, not the mismatch warning.
+TEST_F(FileOutputTests, mux_failure_takes_priority_over_duration_mismatch) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  const std::filesystem::path kInvalidVoutPath = "/invalid_path/muxed.mp4";
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+  FileExport config = fileExportRepository.get();
+  config.setVideoExportFolder(kInvalidVoutPath.string());
+  fileExportRepository.update(config);
+
+  bounceAudio(fio_proc, audioElementRepository);
+
+  EXPECT_FALSE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kMuxFailed);
+}
+
 // Regression test: IAMFExportHelper::getMediaDurationSeconds previously
 // reported the MP4 container's movie-level duration -- the longest track in
 // the file -- as "the video's duration." A source file with a non-visual

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -268,10 +268,10 @@ TEST_F(FileOutputTests, mux_iamf_lpc_1ae_1mp) {
   EXPECT_FALSE(std::filesystem::exists(iamfOutPath));
   EXPECT_FALSE(std::filesystem::exists(videoOutPath));
 
-  // ~5.3 seconds at 48kHz/128 frames per block -- longer than the ~3.8s
-  // default test video, so this plain mux-success check isn't also tripping
-  // the (separately tested) kVideoLongerThanAudio warning.
-  bounceAudio(fio_proc, audioElementRepository, 48000, 128, 2000);
+  // ~3.77 seconds at 48kHz/128 frames per block -- matches the test video's
+  // own duration closely enough that this plain mux-success check isn't also
+  // tripping the (separately tested) duration-mismatch warnings.
+  bounceAudio(fio_proc, audioElementRepository, 48000, 128, 1413);
 
   EXPECT_TRUE(std::filesystem::exists(iamfOutPath));
   EXPECT_TRUE(std::filesystem::exists(videoOutPath));
@@ -333,8 +333,8 @@ TEST_F(FileOutputTests, mux_iamf_container_duration_matches_video) {
   EXPECT_NEAR(outputDuration, videoDuration, 0.1);
 }
 
-// Issue #38: the default bounce (~21ms) is far shorter than the ~3.8s test
-// video, so the mux must still succeed but the export error is set to
+// The default bounce (~21ms) is far shorter than the ~3.77s test video, so
+// the mux must still succeed but the export error is set to
 // kVideoLongerThanAudio for the UI to warn on.
 TEST_F(FileOutputTests, mux_flags_mismatch_when_video_longer_than_audio) {
   const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
@@ -350,18 +350,37 @@ TEST_F(FileOutputTests, mux_flags_mismatch_when_video_longer_than_audio) {
             ExportError::kVideoLongerThanAudio);
 }
 
-// Issue #38: rendering well past the ~3.8s test video's duration means audio
-// is no longer shorter than video, so the mismatch flag must stay clear.
-TEST_F(FileOutputTests, mux_no_mismatch_when_audio_covers_video_duration) {
+// Rendering well past the ~3.77s test video's duration means the exported
+// audio now outlasts the video, so the export error should flip to the
+// opposite-direction warning instead of clearing.
+TEST_F(FileOutputTests, mux_flags_mismatch_when_audio_longer_than_video) {
   const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
   const juce::Uuid kMP = addMixPresentation();
   addAudioElementsToMix(kMP, {kAE});
 
   setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
 
-  // ~5.3 seconds at 48kHz/128 frames per block -- longer than the ~3.8s
+  // ~5.3 seconds at 48kHz/128 frames per block -- longer than the ~3.77s
   // default test video.
   bounceAudio(fio_proc, audioElementRepository, 48000, 128, 2000);
+
+  ASSERT_TRUE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kAudioLongerThanVideo);
+}
+
+// Bouncing audio to closely match the test video's own ~3.77s duration
+// should leave the export error clear in either direction.
+TEST_F(FileOutputTests, mux_no_mismatch_when_durations_match) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+
+  // ~3.77 seconds at 48kHz/128 frames per block -- matches the default test
+  // video's own duration within the mismatch tolerance.
+  bounceAudio(fio_proc, audioElementRepository, 48000, 128, 1413);
 
   ASSERT_TRUE(std::filesystem::exists(videoOutPath));
   EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -268,7 +268,10 @@ TEST_F(FileOutputTests, mux_iamf_lpc_1ae_1mp) {
   EXPECT_FALSE(std::filesystem::exists(iamfOutPath));
   EXPECT_FALSE(std::filesystem::exists(videoOutPath));
 
-  bounceAudio(fio_proc, audioElementRepository);
+  // ~5.3 seconds at 48kHz/128 frames per block -- longer than the ~3.8s
+  // default test video, so this plain mux-success check isn't also tripping
+  // the (separately tested) kVideoLongerThanAudio warning.
+  bounceAudio(fio_proc, audioElementRepository, 48000, 128, 2000);
 
   EXPECT_TRUE(std::filesystem::exists(iamfOutPath));
   EXPECT_TRUE(std::filesystem::exists(videoOutPath));
@@ -331,8 +334,8 @@ TEST_F(FileOutputTests, mux_iamf_container_duration_matches_video) {
 }
 
 // Issue #38: the default bounce (~21ms) is far shorter than the ~3.8s test
-// video, so the export must still succeed (no ExportError) but flag the
-// duration mismatch for the UI to warn on.
+// video, so the mux must still succeed but the export error is set to
+// kVideoLongerThanAudio for the UI to warn on.
 TEST_F(FileOutputTests, mux_flags_mismatch_when_video_longer_than_audio) {
   const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
   const juce::Uuid kMP = addMixPresentation();
@@ -343,8 +346,8 @@ TEST_F(FileOutputTests, mux_flags_mismatch_when_video_longer_than_audio) {
   bounceAudio(fio_proc, audioElementRepository);
 
   ASSERT_TRUE(std::filesystem::exists(videoOutPath));
-  EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
-  EXPECT_TRUE(fileExportRepository.get().getVideoLongerThanAudio());
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kVideoLongerThanAudio);
 }
 
 // Issue #38: rendering well past the ~3.8s test video's duration means audio
@@ -362,7 +365,6 @@ TEST_F(FileOutputTests, mux_no_mismatch_when_audio_covers_video_duration) {
 
   ASSERT_TRUE(std::filesystem::exists(videoOutPath));
   EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
-  EXPECT_FALSE(fileExportRepository.get().getVideoLongerThanAudio());
 }
 
 // Codec param tests. These tests focus on testing advanced codec specific file

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -383,6 +383,31 @@ TEST_F(FileOutputTests, mux_flags_mismatch_when_audio_longer_than_video) {
             ExportError::kAudioLongerThanVideo);
 }
 
+// Regression test: a zero-frame export (e.g. export started and immediately
+// stopped, or every block skipped by shouldBufferBeWritten()) leaves the
+// exported .iamf file with no audio data at all -- muxing that against a
+// real video currently fails outright inside muxVideo() (GPAC's audio-mux
+// stage never produces a destination file for a source with zero audio
+// samples), so the export error must be kMuxFailed, never silently kNoError
+// or a mismatch warning. checkAudioVideoDurationMismatch()'s own guard was
+// simplified to no longer special-case framesWritten_ == 0 (it now only
+// gates on sampleRate_ > 0) so the mismatch check itself stays correct if a
+// future codec path ever does complete a zero-frame mux.
+TEST_F(FileOutputTests, mux_zero_frame_export_fails_mux_not_silently_skips) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
+
+  // Zero blocks -- framesWritten_ never leaves 0.
+  bounceAudio(fio_proc, audioElementRepository, 48000, 128, /*numBlocks=*/0);
+
+  EXPECT_FALSE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kMuxFailed);
+}
+
 // Bouncing audio to closely match the test video's own ~3.77s duration
 // should leave the export error clear in either direction.
 TEST_F(FileOutputTests, mux_no_mismatch_when_durations_match) {
@@ -1146,9 +1171,58 @@ TEST_F(FileOutputTests, time_range_start_beyond_duration) {
   fileExportRepository.update(config);
 }
 
+// Regression test: FileExport's start/end sample indices (and
+// FileOutputProcessor's own sampleTally_ accumulator) were widened from
+// `long` to juce::int64 specifically so a start index past INT32_MAX
+// (~12.4 hours at 48kHz) survives the FileExportRepository round-trip
+// intact. Before the fix, a 32-bit `long` (as on Windows LLP64) would wrap
+// this value -- most likely to a small or negative number -- which would
+// hit the "no range specified" branch (startSampleIdx_ <= 0) and cause the
+// export to incorrectly write every sample instead of none.
+TEST_F(FileOutputTests, time_range_start_beyond_int32_max) {
+  const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
+  const juce::Uuid kMP = addMixPresentation();
+  addAudioElementsToMix(kMP, {kAE});
+
+  setTestExportOpts({.codec = AudioCodec::LPCM});
+
+  constexpr juce::int64 kBeyondInt32Max = 3'000'000'000LL;  // > 2^31 - 1
+
+  // Full 1-second bounce for reference
+  ASSERT_FALSE(std::filesystem::exists(iamfOutPath));
+  bounceAudioForDuration(fio_proc, audioElementRepository, 1.0, kSampleRate,
+                         kSamplesPerFrame);
+  ASSERT_TRUE(std::filesystem::exists(iamfOutPath));
+  const auto fullSize = std::filesystem::file_size(iamfOutPath);
+  std::filesystem::remove(iamfOutPath);
+
+  auto config = fileExportRepository.get();
+  config.setStartSampleIdx(kBeyondInt32Max);
+  config.setEndSampleIdx(0);
+  fileExportRepository.update(config);
+
+  // Confirm the value survived the repository's toValueTree()/fromTree()
+  // round-trip without truncating.
+  ASSERT_EQ(fileExportRepository.get().getStartSampleIdx(), kBeyondInt32Max);
+
+  ASSERT_FALSE(std::filesystem::exists(iamfOutPath));
+  bounceAudioForDuration(fio_proc, audioElementRepository, 1.0, kSampleRate,
+                         kSamplesPerFrame);
+
+  if (std::filesystem::exists(iamfOutPath)) {
+    const auto noAudioSize = std::filesystem::file_size(iamfOutPath);
+    EXPECT_LT(noAudioSize, fullSize);
+    std::filesystem::remove(iamfOutPath);
+  }
+
+  // Reset
+  config.setStartSampleIdx(0);
+  fileExportRepository.update(config);
+}
+
 // Verify sub-second boundary precision using sample counts.
-// startTime and endTime are stored as sample counts (long) in FileExport.
-// This test uses a precise sub-second boundary.
+// startTime and endTime are stored as sample counts (juce::int64) in
+// FileExport. This test uses a precise sub-second boundary.
 TEST_F(FileOutputTests, time_range_subsecond_precision) {
   const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
   const juce::Uuid kMP = addMixPresentation();

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -461,6 +461,10 @@ TEST_F(FileOutputTests, mux_failure_takes_priority_over_duration_mismatch) {
 // silently defeat the mismatch-detection feature this PR adds. Synthesize a
 // video with a 1s video track and a 3s audio track and confirm the video
 // track's own duration is reported, not the longer container duration.
+// This is the only caller of getMediaDurationSeconds -- see its header doc
+// comment for why it has no production caller (muxIAMF()'s
+// outVideoDurationSec out-param covers the production path instead) and is
+// nonetheless kept, tested, and documented as a general-purpose utility.
 TEST_F(FileOutputTests, get_media_duration_uses_video_track_not_container) {
   const std::filesystem::path kMixedDurationVideo =
       std::filesystem::current_path() / "mixed_duration_test.mp4";

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -280,8 +280,15 @@ TEST_F(FileOutputTests, mux_iamf_lpc_1ae_1mp) {
 }
 
 TEST_F(FileOutputTests, mux_iamf_flac_2ae_1mp) {
-  const juce::Uuid kAE1 = addAudioElement(Speakers::kStereo);
-  const juce::Uuid kAE2 = addAudioElement(Speakers::kStereo);
+  // Distinct element names are required: the per-audio-element WAV path is
+  // derived as `<exportFile>_<elementName>.wav`, so two elements sharing the
+  // default name both resolve to the same file. On Windows the second
+  // writer's open() then fails with a sharing violation, recording
+  // kFileWriteFailed -- which, under recordExportErrorIfUnset's
+  // first-recorded-error-wins semantics, masks the duration-mismatch warning
+  // this test asserts on.
+  const juce::Uuid kAE1 = addAudioElement(Speakers::kStereo, "Element One");
+  const juce::Uuid kAE2 = addAudioElement(Speakers::kStereo, "Element Two");
   const juce::Uuid kMP = addMixPresentation();
   addAudioElementsToMix(kMP, {kAE1, kAE2});
 
@@ -302,8 +309,10 @@ TEST_F(FileOutputTests, mux_iamf_flac_2ae_1mp) {
 }
 
 TEST_F(FileOutputTests, mux_iamf_opus_2ae_2mp) {
-  const juce::Uuid kAE1 = addAudioElement(Speakers::kStereo);
-  const juce::Uuid kAE2 = addAudioElement(Speakers::kHOA3);
+  // Distinct element names -- see the note on mux_iamf_flac_2ae_1mp above for
+  // why sharing the default name masks the asserted export error on Windows.
+  const juce::Uuid kAE1 = addAudioElement(Speakers::kStereo, "Element One");
+  const juce::Uuid kAE2 = addAudioElement(Speakers::kHOA3, "Element Two");
   const juce::Uuid kMP1 = addMixPresentation();
   const juce::Uuid kMP2 = addMixPresentation();
   addAudioElementsToMix(kMP1, {kAE1, kAE2});

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -30,6 +30,7 @@
 
 #include "FileOutputTestFixture.h"
 #include "juce_cryptography/juce_cryptography.h"
+#include "processors/file_output/iamf_export_utils/IAMFExportUtil.h"
 #include "processors/tests/FileOutputTestUtils.h"
 #include "substream_rdr/substream_rdr_utils/Speakers.h"
 
@@ -384,6 +385,54 @@ TEST_F(FileOutputTests, mux_no_mismatch_when_durations_match) {
 
   ASSERT_TRUE(std::filesystem::exists(videoOutPath));
   EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
+}
+
+// Regression test: IAMFExportHelper::getMediaDurationSeconds previously
+// reported the MP4 container's movie-level duration -- the longest track in
+// the file -- as "the video's duration." A source file with a non-visual
+// track (e.g. an embedded audio track) longer than its video track would
+// silently defeat the mismatch-detection feature this PR adds. Synthesize a
+// video with a 1s video track and a 3s audio track and confirm the video
+// track's own duration is reported, not the longer container duration.
+TEST_F(FileOutputTests, get_media_duration_uses_video_track_not_container) {
+  const std::filesystem::path kMixedDurationVideo =
+      std::filesystem::current_path() / "mixed_duration_test.mp4";
+  std::filesystem::remove(kMixedDurationVideo);
+
+  juce::StringArray ffmpegArgs;
+  ffmpegArgs.add("-y");
+  ffmpegArgs.add("-f");
+  ffmpegArgs.add("lavfi");
+  ffmpegArgs.add("-t");
+  ffmpegArgs.add("1");
+  ffmpegArgs.add("-i");
+  ffmpegArgs.add("color=c=black:s=64x64");
+  ffmpegArgs.add("-f");
+  ffmpegArgs.add("lavfi");
+  ffmpegArgs.add("-t");
+  ffmpegArgs.add("3");
+  ffmpegArgs.add("-i");
+  ffmpegArgs.add("anullsrc=r=48000:cl=mono");
+  ffmpegArgs.add("-c:v");
+  ffmpegArgs.add("libx264");
+  ffmpegArgs.add("-pix_fmt");
+  ffmpegArgs.add("yuv420p");
+  ffmpegArgs.add("-c:a");
+  ffmpegArgs.add("aac");
+  ffmpegArgs.add(kMixedDurationVideo.string());
+
+  auto [exitCode, output] = executeCommand("ffmpeg", ffmpegArgs);
+  ASSERT_EQ(exitCode, 0) << "ffmpeg fixture generation failed: " << output;
+  ASSERT_TRUE(std::filesystem::exists(kMixedDurationVideo));
+
+  const double kDurationSec =
+      IAMFExportHelper::getMediaDurationSeconds(kMixedDurationVideo.string());
+
+  // The video track is ~1s; the container/audio track is ~3s. A correct
+  // implementation reports the video track's duration.
+  EXPECT_NEAR(kDurationSec, 1.0, 0.1);
+
+  std::filesystem::remove(kMixedDurationVideo);
 }
 
 // Codec param tests. These tests focus on testing advanced codec specific file

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -400,16 +400,16 @@ TEST_F(FileOutputTests, mux_no_mismatch_when_durations_match) {
   EXPECT_EQ(fileExportRepository.get().getExportError(), ExportError::kNoError);
 }
 
-// Regression test: closeFileExport documents that
-// checkAudioVideoDurationMismatch runs unconditionally after a mux attempt and
-// relies on FileExport::recordExportErrorIfUnset's first-recorded-error-wins
-// semantics to stay silent when a more critical failure is already on record --
-// but nothing previously exercised a case where a mux failure AND a genuine
-// duration mismatch would both fire, to confirm the mux failure wins. Point the
-// video export folder at an invalid path (forcing a mux failure) while keeping
-// the video source at the default ~3.77s test video and rendering only the
-// default short (~21ms) bounce, which alone would trip kVideoLongerThanAudio --
-// the export error must still surface as kMuxFailed, not the mismatch warning.
+// Regression test: closeFileExport only runs checkAudioVideoDurationMismatch
+// after a successful mux -- on a mux failure it is skipped entirely (both to
+// avoid opening the untrusted video file on a path that previously never
+// touched it, and because kMuxFailed already wins under
+// FileExport::recordExportErrorIfUnset's first-recorded-error-wins
+// semantics). Point the video export folder at an invalid path (forcing a mux
+// failure) while keeping the video source at the default ~3.77s test video
+// and rendering only the default short (~21ms) bounce, which alone would trip
+// kVideoLongerThanAudio if the mismatch check ran -- the export error must
+// still surface as kMuxFailed, not the mismatch warning.
 TEST_F(FileOutputTests, mux_failure_takes_priority_over_duration_mismatch) {
   const juce::Uuid kAE = addAudioElement(Speakers::kStereo);
   const juce::Uuid kMP = addMixPresentation();

--- a/common/processors/tests/FileOutputProcessor_test.cpp
+++ b/common/processors/tests/FileOutputProcessor_test.cpp
@@ -290,10 +290,15 @@ TEST_F(FileOutputTests, mux_iamf_flac_2ae_1mp) {
   EXPECT_FALSE(std::filesystem::exists(iamfOutPath));
   EXPECT_FALSE(std::filesystem::exists(videoOutPath));
 
+  // Default bounce (~21ms) is far shorter than the fixture video, so this
+  // also exercises (without separately re-testing) the mismatch warning
+  // path covered explicitly by mux_flags_mismatch_when_video_longer_than_audio.
   bounceAudio(fio_proc, audioElementRepository);
 
   EXPECT_TRUE(std::filesystem::exists(iamfOutPath));
   EXPECT_TRUE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kVideoLongerThanAudio);
 }
 
 TEST_F(FileOutputTests, mux_iamf_opus_2ae_2mp) {
@@ -309,10 +314,14 @@ TEST_F(FileOutputTests, mux_iamf_opus_2ae_2mp) {
   EXPECT_FALSE(std::filesystem::exists(iamfOutPath));
   EXPECT_FALSE(std::filesystem::exists(videoOutPath));
 
+  // Default bounce (~21ms) is far shorter than the fixture video -- see the
+  // note on mux_iamf_flac_2ae_1mp above.
   bounceAudio(fio_proc, audioElementRepository);
 
   EXPECT_TRUE(std::filesystem::exists(iamfOutPath));
   EXPECT_TRUE(std::filesystem::exists(videoOutPath));
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kVideoLongerThanAudio);
 }
 
 TEST_F(FileOutputTests, mux_iamf_container_duration_matches_video) {
@@ -322,6 +331,8 @@ TEST_F(FileOutputTests, mux_iamf_container_duration_matches_video) {
 
   setTestExportOpts({.codec = AudioCodec::LPCM, .exportVideo = true});
 
+  // Default bounce (~21ms) is far shorter than the fixture video -- see the
+  // note on mux_iamf_flac_2ae_1mp above.
   bounceAudio(fio_proc, audioElementRepository);
   ASSERT_TRUE(std::filesystem::exists(videoOutPath));
 
@@ -332,6 +343,8 @@ TEST_F(FileOutputTests, mux_iamf_container_duration_matches_video) {
   ASSERT_GT(videoDuration, 0.0);
   ASSERT_GT(outputDuration, 0.0);
   EXPECT_NEAR(outputDuration, videoDuration, 0.1);
+  EXPECT_EQ(fileExportRepository.get().getExportError(),
+            ExportError::kVideoLongerThanAudio);
 }
 
 // The default bounce (~21ms) is far shorter than the ~3.77s test video, so

--- a/common/processors/tests/FileOutputTestUtils.h
+++ b/common/processors/tests/FileOutputTestUtils.h
@@ -83,10 +83,15 @@ static FileProfile profileFromAEs(
 }
 
 // Helper used by multiple tests to render a short non-realtime bounce.
+// `numBlocks` defaults to the original fixed 8-block bounce (~21ms at the
+// default 48kHz/128-frame settings); pass a larger value to render enough
+// audio to exceed a given video's duration (e.g. for duration-mismatch
+// tests).
 static inline void bounceAudio(FileOutputProcessor& fio_proc,
                                AudioElementRepository& audioElementRepository,
                                unsigned sampleRate = 48e3,
-                               unsigned frameSize = 128) {
+                               unsigned frameSize = 128,
+                               unsigned numBlocks = 8) {
   const unsigned kNumChannels = totalAudioChannels(audioElementRepository);
   const auto kSineTone = generateSineWave(440.0f, sampleRate, frameSize);
 
@@ -95,7 +100,7 @@ static inline void bounceAudio(FileOutputProcessor& fio_proc,
 
   juce::AudioBuffer<float> audioBuffer(kNumChannels, frameSize);
   juce::MidiBuffer dummyMidiBuffer;
-  for (int block = 0; block < 8; ++block) {
+  for (unsigned block = 0; block < numBlocks; ++block) {
     for (unsigned i = 0; i < kNumChannels; ++i) {
       audioBuffer.copyFrom(i, 0, kSineTone, 0, 0, frameSize);
     }

--- a/common/processors/tests/FileOutputTestUtils.h
+++ b/common/processors/tests/FileOutputTestUtils.h
@@ -110,14 +110,18 @@ static inline void bounceAudio(FileOutputProcessor& fio_proc,
 }
 
 // Helper used by multiple tests to render a short bounce using the premiere pro
-// file output processor.
+// file output processor. `numBlocks` defaults to the original fixed 8-block
+// bounce (~21ms at the default 48kHz/128-frame settings); pass a larger value
+// to render enough audio to exceed a given video's duration (e.g. for
+// duration-mismatch tests), mirroring bounceAudio's `numBlocks` parameter.
 static inline void bouncePremiereProAudio(
     FileExportRepository& fileExportRepository,
     FilePlaybackRepository& filePlaybackRepository,
     AudioElementRepository& audioElementRepository,
     MixPresentationRepository& mixPresentationRepository,
     MixPresentationLoudnessRepository& mixPresentationLoudnessRepository,
-    unsigned sampleRate = 48e3, unsigned frameSize = 128) {
+    unsigned sampleRate = 48e3, unsigned frameSize = 128,
+    unsigned numBlocks = 8) {
   // First, premiere pro starts a manual export
   auto fileExport = fileExportRepository.get();
   fileExport.setManualExport(true);
@@ -138,7 +142,7 @@ static inline void bouncePremiereProAudio(
 
   juce::AudioBuffer<float> audioBuffer(kNumChannels, frameSize);
   juce::MidiBuffer dummyMidiBuffer;
-  for (int block = 0; block < 8; ++block) {
+  for (unsigned block = 0; block < numBlocks; ++block) {
     for (unsigned i = 0; i < kNumChannels; ++i) {
       audioBuffer.copyFrom(i, 0, kSineTone, 0, 0, frameSize);
     }

--- a/rendererplugin/src/screens/FileExportScreen.cpp
+++ b/rendererplugin/src/screens/FileExportScreen.cpp
@@ -454,7 +454,8 @@ FileExportScreen::FileExportScreen(MainEditor& editor,
   startTimer_.setText(
       timeToString(config.getStartSampleIdx(), startTimeFormat_));
   startTimer_.onTextChanged([this] {
-    long startTime = stringToSamples(startTimer_.getText(), startTimeFormat_);
+    juce::int64 startTime =
+        stringToSamples(startTimer_.getText(), startTimeFormat_);
     if (startTime < 0) {
       juce::String errorMsg = "Invalid time format. Expected: ";
       switch (startTimeFormat_) {
@@ -481,7 +482,7 @@ FileExportScreen::FileExportScreen(MainEditor& editor,
   });
   endTimer_.setText(timeToString(config.getEndSampleIdx(), endTimeFormat_));
   endTimer_.onTextChanged([this] {
-    long endTime = stringToSamples(endTimer_.getText(), endTimeFormat_);
+    juce::int64 endTime = stringToSamples(endTimer_.getText(), endTimeFormat_);
     if (endTime < 0) {
       juce::String errorMsg = "Invalid time format. Expected: ";
       switch (endTimeFormat_) {
@@ -804,7 +805,7 @@ void FileExportScreen::paint(juce::Graphics& g) {
   exportValidation_.setBounds(validationBounds);
 };
 
-juce::String FileExportScreen::timeToString(long sampleCount,
+juce::String FileExportScreen::timeToString(juce::int64 sampleCount,
                                             TimeFormat format) {
   const int sr = repository_->get().getSampleRate();
   const double seconds = (sr > 0) ? static_cast<double>(sampleCount) / sr : 0.0;
@@ -826,26 +827,30 @@ juce::String FileExportScreen::timeToString(long sampleCount,
   }
 }
 
-long FileExportScreen::stringToSamples(juce::String val, TimeFormat format) {
+juce::int64 FileExportScreen::stringToSamples(juce::String val,
+                                              TimeFormat format) {
   const int sr = repository_->get().getSampleRate();
   switch (format) {
     case TimeFormat::HoursMinutesSeconds:
-      return static_cast<long>(TimeFormatConverter::hmsToSeconds(val) * sr);
+      return static_cast<juce::int64>(TimeFormatConverter::hmsToSeconds(val) *
+                                      sr);
     case TimeFormat::BarsBeats:
       if (cachedBpm_.hasValue() && cachedTimeSignature_.hasValue())
-        return static_cast<long>(TimeFormatConverter::barsBeatsToSeconds(
-                                     val, *cachedBpm_, *cachedTimeSignature_) *
-                                 sr);
+        return static_cast<juce::int64>(
+            TimeFormatConverter::barsBeatsToSeconds(val, *cachedBpm_,
+                                                    *cachedTimeSignature_) *
+            sr);
       return -1;
     case TimeFormat::Timecode:
       if (cachedFrameRate_.hasValue())
-        return static_cast<long>(
+        return static_cast<juce::int64>(
             TimeFormatConverter::timecodeToMs(
                 val, cachedFrameRate_->getEffectiveRate()) /
             1000.0 * sr);
       return -1;
     default:
-      return static_cast<long>(TimeFormatConverter::hmsToSeconds(val) * sr);
+      return static_cast<juce::int64>(TimeFormatConverter::hmsToSeconds(val) *
+                                      sr);
   }
 }
 

--- a/rendererplugin/src/screens/FileExportScreen.h
+++ b/rendererplugin/src/screens/FileExportScreen.h
@@ -63,8 +63,8 @@ class FileExportScreen : public juce::Component,
   void configureCustomCodecParameter(AudioCodec format);
 
   // Time format conversion methods
-  juce::String timeToString(long sampleCount, TimeFormat format);
-  long stringToSamples(juce::String val, TimeFormat format);
+  juce::String timeToString(juce::int64 sampleCount, TimeFormat format);
+  juce::int64 stringToSamples(juce::String val, TimeFormat format);
 
   // Helper methods for timing info and format availability
   void updateTimingInfoFromHost();


### PR DESCRIPTION
## Summary

When exporting IAMF audio muxed with a video, warn the user if the video and
exported audio durations don't match, in either direction, so a length
mismatch is never silently shipped. The mux itself still succeeds; this
surfaces as a warning, not an export failure.

- `FileOutputProcessor::closeFileExport` computes the exported audio's
  duration from the per-audio-element WAV writer's frame count and the
  video's duration via a new `IAMFExportHelper::getMediaDurationSeconds`
  (prefers the video track's own duration over the movie/container-level
  duration, since a file with a longer non-visual track would otherwise
  report the wrong length). Two new `ExportError` values,
  `kVideoLongerThanAudio` and `kAudioLongerThanVideo`, are set when the
  durations differ by more than a small tolerance; a hard export/mux error
  always takes priority over either mismatch if both are true.
- `ExportErrorBanner` (the same banner that already reports export failures
  like a failed mux) is extended to also show these warnings when the mux
  otherwise succeeded, reusing the existing UI surface rather than adding a
  new banner.
- No warning when the video and audio durations match within tolerance; the
  reverse direction (audio longer than video) is also flagged, since a
  silent mismatch is equally undesirable either way.
- `muxVideo()`/`muxIAMF()` return the video duration they already compute
  internally (from the already-open destination file handle) via a new
  `outVideoDurationSec` out-param, avoiding a redundant second parse of the
  video file for the duration check.
- `sampleTally_`/`startSampleIdx_`/`endSampleIdx_`/`framesWritten_` widened
  from `long`/32-bit counters to 64-bit (`juce::int64`), fixing an overflow
  on long exports under Windows LLP64.

## Test plan

- `FileOutputTests.mux_flags_mismatch_when_video_longer_than_audio` --
  default (~21ms) audio against the ~3.8s test video sets
  `kVideoLongerThanAudio`, mux still succeeds.
- `FileOutputTests.mux_flags_mismatch_when_audio_longer_than_video` --
  ~5.3s of audio against the same video sets `kAudioLongerThanVideo`.
- `FileOutputTests.mux_no_mismatch_when_durations_match` -- ~3.77s of audio
  matching the test video's own duration leaves the error clear.
- `FileOutputTests.get_media_duration_uses_video_track_not_container` -- a
  synthesized file with a 1s video track and a 3s audio track reports the
  video track's duration, not the longer container duration.
- `FileOutputTests.pp_flags_mismatch_when_video_longer_than_audio`,
  `pp_flags_mismatch_when_audio_longer_than_video`,
  `pp_no_mismatch_when_durations_match` -- mirror the above for the
  Premiere Pro export path, which has its own `framesWritten_` tracking.
- `test_export_error_banner` -- new `isWarningState`,
  `messageForStatePrioritizesErrorOverMismatch`, `shouldShowWarning`,
  `shouldHideWarning` cases.
- A zero-frame export against a video fails the mux outright (`kMuxFailed`)
  rather than silently completing, and a start/end sample index round-trip
  test past `INT32_MAX` passes.
- Full `ctest` suite passes; changed files are clang-format clean.
