### PR TITLE
Adjust mux tolerance

### DIFF
--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -306,7 +306,10 @@ void FileOutputProcessor::checkAudioVideoDurationMismatch(
   if (!(sampleRate_ > 0)) {
     return;
   }
-  constexpr double kDurationMismatchToleranceSec = 0.05;
+  // A half second tolerance accounts for some drift, 
+  // won't be noticed in practice, and handles the 
+  // slight mismatch often created in recorded video (~2-5 frames)
+  constexpr double kDurationMismatchToleranceSec = 0.5;
   const double kAudioDurationSec =
       static_cast<double>(framesWritten_) / sampleRate_;
   if (videoDurationSec <= 0.0) {


### PR DESCRIPTION
Adjust mix tolerance to 0.5 seconds from 55 milliseconds

### Description
Recorded video examples, where we extract audio from video and then remux, show a 2-5 frame difference between audio and video lengths, leading to a difference of approximately 0.05 to 0.15 seconds.

As 0.5 seconds of silence is unlikely to be noticed in practice, increasing the tolerance to a nicer amount, the goal of the warning is to flag when there is a serious mismatch, not barely noticeable ones.

### Changes
- Adjusted tolerance value

### Validation and Acceptance Criteria
Briefly describe how this PR meets any acceptance criteria defined in the linked issue.
- Manually tested
