### PR TITLE
Increase tolerance of muxing error to account for AV frame mismatch

### DIFF
--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -306,7 +306,10 @@ void FileOutputProcessor::checkAudioVideoDurationMismatch(
   if (!(sampleRate_ > 0)) {
     return;
   }
-  constexpr double kDurationMismatchToleranceSec = 0.05;
+  // Failure tolerance is reasonably large to avoid false positives as 0.5s of
+  // silence is unlikely to be noticed and video/audio recordings seem to often
+  // have a mismatch of ~2-10 frames, which is ~0.05-0.2s at 48kHz. 
+  constexpr double kDurationMismatchToleranceSec = 0.5;
   const double kAudioDurationSec =
       static_cast<double>(framesWritten_) / sampleRate_;
   if (videoDurationSec <= 0.0) {

--- a/common/processors/file_output/FileOutputProcessor.cpp
+++ b/common/processors/file_output/FileOutputProcessor.cpp
@@ -308,7 +308,7 @@ void FileOutputProcessor::checkAudioVideoDurationMismatch(
   }
   // Failure tolerance is reasonably large to avoid false positives as 0.5s of
   // silence is unlikely to be noticed and video/audio recordings seem to often
-  // have a mismatch of ~2-10 frames, which is ~0.05-0.2s at 48kHz. 
+  // have a mismatch of ~2-10 frames, which is ~0.05-0.2s at 48kHz.
   constexpr double kDurationMismatchToleranceSec = 0.5;
   const double kAudioDurationSec =
       static_cast<double>(framesWritten_) / sampleRate_;


### PR DESCRIPTION
### Description
Mixing almost always produces an error now as typical recordings often have a slight 2-10 frame mismatch between audio and video. Since this is imperceptible, greatly increase the tolerance as the goal is to flag errors in cases where the mismatch will be significant.

### Changes
Increase tolerance scope

### Validation and Acceptance Criteria
- Manual testing only
